### PR TITLE
Trace-mode hotfix for undefined symbols (new C++ compiler)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.arm_iface_gcc_dep
+*.arm_iface_gcc_o
+*.arm_vverb_gcc_dep
+Makefile.depend*
+*.a
+*.a.fresh
+*.so
+stat-manager/stat-manager
+stat-manager/stat-sample
+stat-manager/stat-collapse

--- a/components/FastCache/CoherenceProtocol.hpp
+++ b/components/FastCache/CoherenceProtocol.hpp
@@ -325,6 +325,18 @@ protected:
   }
 };
 
+// Msutherl: Undefined symbol fix
+const CoherenceProtocol::access_t CoherenceProtocol::kReadAccess;
+const CoherenceProtocol::access_t CoherenceProtocol::kWriteAccess;
+const CoherenceProtocol::access_t CoherenceProtocol::kFetchAccess;
+const CoherenceProtocol::access_t CoherenceProtocol::kUpgrade;
+const CoherenceProtocol::access_t CoherenceProtocol::kEvictClean;
+const CoherenceProtocol::access_t CoherenceProtocol::kEvictWritable;
+const CoherenceProtocol::access_t CoherenceProtocol::kEvictDirty;
+const CoherenceProtocol::access_t CoherenceProtocol::kStoreAccess;
+const CoherenceProtocol::access_t CoherenceProtocol::kNAWAccess;
+const CoherenceProtocol::access_t CoherenceProtocol::kUnknownAccess;
+ 
 #define CP CoherenceProtocol
 
 // Required specializations


### PR DESCRIPTION
@neo-apz Please test this tomorrow and merge it when you agree that it works with the master branch of qemu, libqflex, and flexus.