### PR TITLE
Enables RegressionTracker magic breakpoints, 1 per core.

### DIFF
--- a/components/MagicBreakQEMU/breakpoint_tracker.cpp
+++ b/components/MagicBreakQEMU/breakpoint_tracker.cpp
@@ -520,9 +520,9 @@ class RegressionTrackerImpl : public RegressionTracker {
         std::vector<int> struct_id;
     public:
   void OnMagicBreakpoint( Qemu::API::conf_object_t * aCpu, long long aBreakpoint) {
-    DBG_(Dev, ( << "Regression Testing Breakpoint: " << aBreakpoint) );
+    DBG_(Tmp, ( << "Regression Testing Breakpoint: " << aBreakpoint) );
     if (aBreakpoint == theStopBreakpoint) {
-      DBG_(Dev, ( << "Stop breakpoint.  Terminating Simulation.") );
+      DBG_(Tmp, ( << "Stop breakpoint.  Terminating Simulation.") );
       Flexus::Core::theFlexus->terminateSimulation();
     }
     theLastBreakpoint = aBreakpoint;

--- a/components/MagicBreakQEMU/breakpoint_tracker.cpp
+++ b/components/MagicBreakQEMU/breakpoint_tracker.cpp
@@ -53,8 +53,8 @@
 #include <core/qemu/configuration_api.hpp>
 #include <core/flexus.hpp>
 #include <core/boost_extensions/padded_string_cast.hpp>
-
 #include <components/MagicBreakQEMU/breakpoint_tracker.hpp>
+#include <core/component.hpp>
 
 #define DBG_DefineCategories MagicBreak, IterationCount, Termination, IterationTrace, DBTransactionTrace, SimPrint
 #define DBG_SetDefaultOps AddCat(MagicBreak)
@@ -515,6 +515,9 @@ public:
 };
 
 class RegressionTrackerImpl : public RegressionTracker {
+    private:
+        int system_width;
+        std::vector<int> struct_id;
     public:
   void OnMagicBreakpoint( Qemu::API::conf_object_t * aCpu, long long aBreakpoint) {
     DBG_(Dev, ( << "Regression Testing Breakpoint: " << aBreakpoint) );
@@ -525,28 +528,30 @@ class RegressionTrackerImpl : public RegressionTracker {
     theLastBreakpoint = aBreakpoint;
   }
 
-  //does not go here
-//  Qemu::API::QEMU_insert_callback(
-//		    Qemu::API::QEMU_magic_instruction
-//		  , (void*) this
-//		  , RegressionTrackerMagicBreakpoint
-//		  );
-
   int64_t theLastBreakpoint;
   int64_t theStopBreakpoint;
 
 public:
   RegressionTrackerImpl() 
-    : theLastBreakpoint(0)
+    : system_width(ComponentManager::getComponentManager().systemWidth())
+    , struct_id(system_width)
+    , theLastBreakpoint(0)
     , theStopBreakpoint(1)
   {
-      //I think goes here? Possibly it should go in enable()
-    Qemu::API::QEMU_insert_callback(
-				    QEMUFLEX_GENERIC_CALLBACK,
-				    Qemu::API::QEMU_magic_instruction,
-				    (void*) this,
-				    (void *) &RegressionTrackerMagicBreakpoint
-				    );
+      for(int i = 0; i < system_width; i++) { // init a callback for each cpu
+          int r = Qemu::API::QEMU_insert_callback(
+                  i, // cpu-idx
+                  Qemu::API::QEMU_magic_instruction,
+                  (void*) this,
+                  (void *) &RegressionTrackerMagicBreakpoint
+                  );
+          if( r == -1 ) {
+              DBG_Assert(false,(<<"Failed to register RegressionTrackerImpl structure with QEMU, cpu_id = " << i));
+          } else {
+              struct_id.at(i) = r; // will throw if out of range
+              DBG_(Dev,(<<"Successfully registered RegressionTrackerMagicBreakpoint with QEMU, cpu_id = " << i << ", struct id = " << r));
+          }
+      }
   }
 
   void enable() {


### PR DESCRIPTION
- This code effectively tests multi-core magic BPs. Most of the implementation code is actually in libqflex as well as QEMU. 