### PR TITLE
Fixes ROR operation to always pass explicit input width (64 or 32)

### DIFF
--- a/components/armDecoder/Operations.cpp
+++ b/components/armDecoder/Operations.cpp
@@ -406,12 +406,6 @@ typedef struct ROR : public Operation {
     uint64_t input = boost::get<uint64_t>(operands[0]);
     uint64_t shift_size = boost::get<uint64_t>(operands[1]);
     uint64_t input_size = boost::get<uint64_t>(operands[2]);
-
-    if (input_size == 1)
-      input_size = 64;
-    else
-      input_size = 32;
-
     return ror((uint64_t)input, (uint64_t)input_size, (uint64_t)shift_size);
   }
   virtual char const *describe() const {

--- a/components/armDecoder/SemanticActions/BitFieldAction.cpp
+++ b/components/armDecoder/SemanticActions/BitFieldAction.cpp
@@ -101,7 +101,7 @@ struct BitFieldAction : public PredicatedSemanticAction {
         uint64_t dst = boost::get<uint64_t>(theInstruction->operand(theOperandCode2));
 
         std::unique_ptr<Operation> ror = operation(kROR_);
-        std::vector<Operand> operands = {src, theR, uint64_t(the64)};
+        std::vector<Operand> operands = {src, theR, (the64 ? (uint64_t)64 : (uint64_t)32)};
         uint64_t res = boost::get<uint64_t>(ror->operator()(operands));
 
         // perform bitfield move on low bits

--- a/components/armDecoder/encodings/armDataProcReg.cpp
+++ b/components/armDecoder/encodings/armDataProcReg.cpp
@@ -458,6 +458,7 @@ arminst ADDSUB_EXTENDED(armcode const &aFetchedOpcode, uint32_t aCPU, int64_t aS
   std::vector<std::list<InternalDependance>> rs_deps(1), rs2_deps(2);
 
   if (shift_amount > 4) {
+    delete inst;
     return unallocated_encoding(aFetchedOpcode, aCPU, aSequenceNo);
   }
 
@@ -508,6 +509,7 @@ arminst LOGICAL(armcode const &aFetchedOpcode, uint32_t aCPU, int64_t aSequenceN
   uint32_t n = extract32(aFetchedOpcode.theOpcode, 21, 1);
 
   if (!sf && (shift_amount & (1 << 5))) {
+    delete inst;
     return unallocated_encoding(aFetchedOpcode, aCPU, aSequenceNo);
   }
 

--- a/components/armDecoder/encodings/armSharedFunctions.cpp
+++ b/components/armDecoder/encodings/armSharedFunctions.cpp
@@ -515,13 +515,11 @@ uint64_t ones(uint64_t length) {
 uint64_t ror(uint64_t input, uint64_t input_size, uint64_t shift_size) {
   uint64_t filter = (input_size == 32) ? 0xffffffff : (uint64_t)-1;
   DBG_Assert(input_size == 64 || input_size == 32);
-
   uint64_t mask = ones(shift_size);
   uint64_t remaining_bits = input & mask;
 
   input >>= shift_size;
   remaining_bits <<= (input_size - shift_size);
-
   return (remaining_bits | input) & filter;
 }
 


### PR DESCRIPTION
Also remove two rare memory leaks