### PR TITLE
Add sysreg interface and refactor previous classes

### DIFF
--- a/components/armDecoder/Effects.hpp
+++ b/components/armDecoder/Effects.hpp
@@ -191,8 +191,8 @@ Effect *updateUnconditional(SemanticInstruction *inst, VirtualMemoryAddress aTar
 Effect *updateUnconditional(SemanticInstruction *inst, eOperandCode anOperandCode);
 Effect *updateCall(SemanticInstruction *inst, VirtualMemoryAddress aTarget);
 Effect *updateNonBranch(SemanticInstruction *inst);
-Effect *readPR(SemanticInstruction *inst, ePrivRegs aPR);
-Effect *writePR(SemanticInstruction *inst, ePrivRegs aPR);
+Effect *readPR(SemanticInstruction *inst, ePrivRegs aPR, std::unique_ptr<SysRegInfo> aRI);
+Effect *writePR(SemanticInstruction *inst, ePrivRegs aPR, std::unique_ptr<SysRegInfo> aRI);
 Effect *writePSTATE(SemanticInstruction *inst, uint8_t anOp1, uint8_t anOp2);
 Effect *writeNZCV(SemanticInstruction *inst);
 Effect *clearExclusiveMonitor(SemanticInstruction *inst);

--- a/components/uArchARM/CoreModel/construct.cpp
+++ b/components/uArchARM/CoreModel/construct.cpp
@@ -395,7 +395,7 @@ void CoreImpl::writePR(uint32_t aPR, uint64_t aVal) {
 }
 // read physical register
 uint64_t CoreImpl::readPR(ePrivRegs aPR) {
-  return getPriv(aPR).readfn(this);
+  return getPriv(aPR)->readfn(this);
 }
 bool CoreImpl::isAARCH64() {
   return theAARCH64;
@@ -407,8 +407,8 @@ uint32_t CoreImpl::getSPSel() {
   return thePSTATE & PSTATE_SP;
 }
 void CoreImpl::setSPSel(uint32_t aVal) {
-  SysRegInfo &ri = getPriv(kSPSel);
-  ri.writefn(this, aVal);
+  std::unique_ptr<SysRegInfo> ri = getPriv(kSPSel);
+  ri->writefn(this, aVal);
 }
 void CoreImpl::setSP_el(uint8_t anId, uint64_t aVal) {
   DBG_Assert(anId >= 0 || anId < 4);

--- a/components/uArchARM/CoreModel/coreModelImpl.hpp
+++ b/components/uArchARM/CoreModel/coreModelImpl.hpp
@@ -732,6 +732,9 @@ public:
   void setPC(uint64_t aPC);
   void setDAIF(uint32_t aDAIF);
 
+  /* Msutherl: API to read system register value using QEMU encoding */
+  uint64_t readUnhashedSysReg(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn, uint8_t crm);
+
   // Interface to Memory Unit
   //==========================================================================
   void breakMSHRLink(memq_t::index<by_insn>::type::iterator iter);
@@ -774,8 +777,6 @@ public:
 
   void SystemRegisterTrap(uint8_t target_el, uint8_t op0, uint8_t op2, uint8_t op1, uint8_t crn,
                           uint8_t rt, uint8_t crm, uint8_t dir);
-
-  SysRegInfo &getSysRegInfo(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn, uint8_t crm);
 
 private:
   bool hasSnoopBuffer() const {

--- a/components/uArchARM/CoreModel/cycle.cpp
+++ b/components/uArchARM/CoreModel/cycle.cpp
@@ -1041,11 +1041,6 @@ SCTLR_EL CoreImpl::_SCTLR(uint32_t anELn) {
   return SCTLR_EL(theSCTLR_EL[anELn]);
 }
 
-SysRegInfo &CoreImpl::getSysRegInfo(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn,
-                                    uint8_t crm) {
-  return getPriv(opc0, opc1, opc2, crn, crm);
-}
-
 void CoreImpl::increaseEL() {
   uint32_t el = extract32(thePSTATE, 2, 2);
   if (el < 0 || el >= 1)

--- a/components/uArchARM/CoreModel/registers.cpp
+++ b/components/uArchARM/CoreModel/registers.cpp
@@ -349,4 +349,10 @@ void CoreImpl::compareARMState(armState &aLeft, armState &aRight) {
   //  aRight.theASI << std::dec ));
 }
 
+/* Msutherl: API to read system register value using QEMU encoding */
+uint64_t CoreImpl::readUnhashedSysReg(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn,
+                                      uint8_t crm) {
+  return theQEMUCPU->read_sysreg_from_qemu(opc0, opc1, opc2, crn, crm);
+}
+
 } // namespace nuArchARM

--- a/components/uArchARM/systemRegister.cpp
+++ b/components/uArchARM/systemRegister.cpp
@@ -48,23 +48,25 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <core/MakeUniqueWrapper.hpp>
 
 namespace nuArchARM {
 
 /* Minimal set of EL0-visible registers. This will need to be expanded
  * significantly for system emulation of AArch64 CPUs.
  */
-struct NZCV : public SysRegInfo {
+class NZCV_ : public SysRegInfo {
+public:
   std::string name = "NZCV";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 2;
-  eAccessRight access = kPL0_RW;
-  eRegInfo type = kARM_NZCV;
-  uint64_t resetvalue = -1;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 2;
+  static const eAccessRight access = kPL0_RW;
+  static const eRegInfo type = kARM_NZCV;
+  static const uint64_t resetvalue = -1;
   virtual void writefn(uArchARM *aCore, uint64_t aVal) override {
     std::bitset<8> a(aCore->_PSTATE().d());
     std::bitset<8> b(aVal);
@@ -77,24 +79,30 @@ struct NZCV : public SysRegInfo {
   virtual uint64_t readfn(uArchARM *aCore) override {
     return aCore->_PSTATE().NZCV();
   }
-} NZCV_;
 
-struct DAIF : public SysRegInfo {
+  NZCV_()
+      : SysRegInfo("NZCV_", NZCV_::state, NZCV_::type, NZCV_::opc0, NZCV_::opc1, NZCV_::opc2,
+                   NZCV_::crn, NZCV_::crm, NZCV_::access) {
+  }
+};
+
+class DAIF_ : public SysRegInfo {
+public:
   std::string name = "DAIF";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 1;
-  uint8_t crn = 4;
-  uint8_t crm = 2;
-  eAccessRight access = kPL0_RW;
-  eRegInfo type = kARM_NO_RAW;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 1;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 2;
+  static const eAccessRight access = kPL0_RW;
+  static const eRegInfo type = kARM_NO_RAW;
   uint64_t resetvalue = -1;
 
   virtual eAccessResult accessfn(uArchARM *aCore) {
-    DBG_Assert(false);
-    return kACCESS_TRAP;
-  } // FIXME /*aa64_daif_access*/
+    return kACCESS_OK; // access OK since we assume the access right is EL0_RW
+  }
+
   virtual void writefn(uArchARM *aCore, uint64_t aVal) override {
     aCore->setDAIF(aVal);
   } // FIXME
@@ -104,18 +112,23 @@ struct DAIF : public SysRegInfo {
   virtual uint64_t readfn(uArchARM *aCore) override {
     return aCore->_PSTATE().DAIF();
   }
-} DAIF_;
+  DAIF_()
+      : SysRegInfo("DAIF_", DAIF_::state, DAIF_::type, DAIF_::opc0, DAIF_::opc1, DAIF_::opc2,
+                   DAIF_::crn, DAIF_::crm, DAIF_::access) {
+  }
+};
 
-struct TPIDR_EL0 : public SysRegInfo {
+class TPIDR_EL0_ : public SysRegInfo {
+public:
   std::string name = "TPIDR_EL0";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 2;
-  uint8_t crn = 13;
-  uint8_t crm = 0;
-  eAccessRight access = kPL0_RW;
-  eRegInfo type = kARM_NO_RAW;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 2;
+  static const uint8_t crn = 13;
+  static const uint8_t crm = 0;
+  static const eAccessRight access = kPL0_RW;
+  static const eRegInfo type = kARM_NO_RAW;
   uint64_t resetvalue = -1;
 
   virtual eAccessResult accessfn(uArchARM *aCore) {
@@ -131,19 +144,25 @@ struct TPIDR_EL0 : public SysRegInfo {
   virtual uint64_t readfn(uArchARM *aCore) override {
     return aCore->getTPIDR(0);
   }
-} TPIDR_EL0_;
+  TPIDR_EL0_()
+      : SysRegInfo("TPIDR_EL0_", TPIDR_EL0_::state, TPIDR_EL0_::type, TPIDR_EL0_::opc0,
+                   TPIDR_EL0_::opc1, TPIDR_EL0_::opc2, TPIDR_EL0_::crn, TPIDR_EL0_::crm,
+                   TPIDR_EL0_::access) {
+  }
+};
 
-struct FPCR : public SysRegInfo {
+class FPCR_ : public SysRegInfo {
+public:
   std::string name = "FPCR";
-  eRegExecutionState state = kARM_STATE_AA64;
+  static const eRegExecutionState state = kARM_STATE_AA64;
   // MARK: Edited to match ARM v8-A ISA Manual, page C5-374 (Section 5.2.7)
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 4;
-  eAccessRight access = kPL0_RW;
-  eRegInfo type;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 4;
+  static const eAccessRight access = kPL0_RW;
+  static const eRegInfo type = kARM_SPECIAL;
   uint64_t resetvalue = -1;
 
   /* Override for accessfn(). FPSR can be accessed as RW from EL0 and EL1 */
@@ -159,19 +178,24 @@ struct FPCR : public SysRegInfo {
   virtual void writefn(uArchARM *aCore, uint64_t aVal) override {
     aCore->setFPCR(aVal);
   } // /*aa64_fpcr_write*/
-} FPCR_;
+  FPCR_()
+      : SysRegInfo("FPCR_", FPCR_::state, FPCR_::type, FPCR_::opc0, FPCR_::opc1, FPCR_::opc2,
+                   FPCR_::crn, FPCR_::crm, FPCR_::access) {
+  }
+};
 
-struct FPSR : public SysRegInfo {
+class FPSR_ : public SysRegInfo {
+public:
   std::string name = "FPSR";
-  eRegExecutionState state = kARM_STATE_AA64;
+  static const eRegExecutionState state = kARM_STATE_AA64;
   // MARK: Edited to match ARM v8-A ISA Manual, page C5-378 (Section 5.2.8)
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 1;
-  uint8_t crn = 4;
-  uint8_t crm = 4;
-  eAccessRight access = kPL0_RW;
-  eRegInfo type;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 1;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 4;
+  static const eAccessRight access = kPL0_RW;
+  static const eRegInfo type = kARM_SPECIAL;
   uint64_t resetvalue = -1; // architecturally undefined as per manual
 
   /* Override for accessfn(). FPSR can be accessed as RW from EL0 and EL1 */
@@ -187,99 +211,132 @@ struct FPSR : public SysRegInfo {
   virtual void writefn(uArchARM *aCore, uint64_t aVal) override {
     aCore->setFPSR(aVal);
   } /*aa64_fpsr_write*/
-} FPSR_;
+  FPSR_()
+      : SysRegInfo("FPSR_", FPSR_::state, FPSR_::type, FPSR_::opc0, FPSR_::opc1, FPSR_::opc2,
+                   FPSR_::crn, FPSR_::crm, FPSR_::access) {
+  }
+};
 
-struct DCZID_EL0 : public SysRegInfo {
+class DCZID_EL0_ : public SysRegInfo {
+public:
   std::string name = "DCZID_EL0";
-  eRegExecutionState state;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 7;
-  uint8_t crn = 0;
-  uint8_t crm = 0;
-  eAccessRight access = kPL0_R;
-  eRegInfo type = kARM_NO_RAW;
+  static const eRegExecutionState state = kARM_STATE_AA64; // FIXME: confirm this
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 7;
+  static const uint8_t crn = 0;
+  static const uint8_t crm = 0;
+  static const eAccessRight access = kPL0_R;
+  static const eRegInfo type = kARM_NO_RAW;
   uint64_t resetvalue = -1;
 
   virtual uint64_t readfn(uArchARM *aCore) override {
     return aCore->readDCZID_EL0();
   }
-} DCZID_EL0_;
+  DCZID_EL0_()
+      : SysRegInfo("DCZID_EL0_", DCZID_EL0_::state, DCZID_EL0_::type, DCZID_EL0_::opc0,
+                   DCZID_EL0_::opc1, DCZID_EL0_::opc2, DCZID_EL0_::crn, DCZID_EL0_::crm,
+                   DCZID_EL0_::access) {
+  }
+};
 
-struct DC_ZVA : public SysRegInfo {
+class DC_ZVA_ : public SysRegInfo {
+public:
   std::string name = "DC_ZVA";
-  eRegExecutionState state;
-  uint8_t opc0 = 1;
-  uint8_t opc1 = 3;
-  uint8_t opc2 = 1;
-  uint8_t crn = 7;
-  uint8_t crm = 4;
-  eAccessRight access = kPL0_W;
-  eRegInfo type = kARM_DC_ZVA;
+  static const eRegExecutionState state = kARM_STATE_AA64; // FIXME: confirm this
+  static const uint8_t opc0 = 1;
+  static const uint8_t opc1 = 3;
+  static const uint8_t opc2 = 1;
+  static const uint8_t crn = 7;
+  static const uint8_t crm = 4;
+  static const eAccessRight access = kPL0_W;
+  static const eRegInfo type = kARM_DC_ZVA;
   uint64_t resetvalue = -1;
   virtual eAccessResult accessfn(uArchARM *aCore) override {
     return aCore->accessZVA();
   }
-} DC_ZVA_;
+  DC_ZVA_()
+      : SysRegInfo("DC_ZVA_", DC_ZVA_::state, DC_ZVA_::type, DC_ZVA_::opc0, DC_ZVA_::opc1,
+                   DC_ZVA_::opc2, DC_ZVA_::crn, DC_ZVA_::crm, DC_ZVA_::access) {
+  }
+};
 
-struct CURRENT_EL : public SysRegInfo {
+class CURRENT_EL_ : public SysRegInfo {
+public:
   std::string name = "CURRENT_EL";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 0;
-  uint8_t opc2 = 2;
-  uint8_t crn = 4;
-  uint8_t crm = 2;
-  eAccessRight access = kPL1_R;
-  eRegInfo type = kARM_CURRENTEL;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 0;
+  static const uint8_t opc2 = 2;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 2;
+  static const eAccessRight access = kPL1_R;
+  static const eRegInfo type = kARM_CURRENTEL;
   uint64_t resetvalue = -1;
 
-} CURRENT_EL_;
+  CURRENT_EL_()
+      : SysRegInfo("CURRENT_EL_", CURRENT_EL_::state, CURRENT_EL_::type, CURRENT_EL_::opc0,
+                   CURRENT_EL_::opc1, CURRENT_EL_::opc2, CURRENT_EL_::crn, CURRENT_EL_::crm,
+                   CURRENT_EL_::access) {
+  }
+};
 
-struct ELR_EL1 : public SysRegInfo {
-  std::string name = "ELR_EL1";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 0;
-  uint8_t opc2 = 1;
-  uint8_t crn = 4;
-  uint8_t crm = 0;
-  eAccessRight access = kPL1_RW;
-  eRegInfo type = kARM_ALIAS;
+class ELR_EL1_ : public SysRegInfo {
+public:
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 0;
+  static const uint8_t opc2 = 1;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 0;
+  static const eAccessRight access = kPL1_RW;
+  static const eRegInfo type = kARM_ALIAS;
+
+  ELR_EL1_()
+      : SysRegInfo("ELR_EL1", ELR_EL1_::state, ELR_EL1_::type, ELR_EL1_::opc0, ELR_EL1_::opc1,
+                   ELR_EL1_::opc2, ELR_EL1_::crn, ELR_EL1_::crm, ELR_EL1_::access) {
+  }
+};
+
+class SPSR_EL1_ : public SysRegInfo {
+public:
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 0;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 0;
+  static const eAccessRight access = kPL1_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
-} ELR_EL1_;
 
-struct SPSR_EL1 : public SysRegInfo {
-  std::string name = "SPSR_EL1";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 0;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 0;
-  eAccessRight access = kPL1_RW;
-  eRegInfo type = kARM_ALIAS;
-  uint64_t resetvalue = -1;
-
+  /*
   virtual uint64_t readfn(uArchARM *aCore) override {
     return aCore->getSP_el(1);
   }
-} SPSR_EL1_;
+  */
+
+  SPSR_EL1_()
+      : SysRegInfo("SPSR_EL1", SPSR_EL1_::state, SPSR_EL1_::type, SPSR_EL1_::opc0, SPSR_EL1_::opc1,
+                   SPSR_EL1_::opc2, SPSR_EL1_::crn, SPSR_EL1_::crm, SPSR_EL1_::access) {
+  }
+};
 
 /* We rely on the access checks not allowing the guest to write to the
  * state field when SPSel indicates that it's being used as the stack
  * pointer.
  */
-struct SP_EL0 : public SysRegInfo {
+class SP_EL0_ : public SysRegInfo {
+public:
   std::string name = "SP_EL0";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 0;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 1;
-  eAccessRight access = kPL1_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 0;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 1;
+  static const eAccessRight access = kPL1_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
 
   virtual uint64_t readfn(uArchARM *aCore) override {
@@ -294,36 +351,50 @@ struct SP_EL0 : public SysRegInfo {
     aCore->setSP_el(0, aVal);
   }
 
-} SP_EL0_;
+  SP_EL0_()
+      : SysRegInfo("SP_EL0", SP_EL0_::state, SP_EL0_::type, SP_EL0_::opc0, SP_EL0_::opc1,
+                   SP_EL0_::opc2, SP_EL0_::crn, SP_EL0_::crm, SP_EL0_::access) {
+  }
+};
 
-struct SP_EL1 : public SysRegInfo {
+class SP_EL1_ : public SysRegInfo {
+public:
   std::string name = "SP_EL1";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 4;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 1;
-  eAccessRight access = kPL2_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 4;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 1;
+  static const eAccessRight access = kPL2_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
+
+  virtual uint64_t readfn(uArchARM *aCore) override {
+    return aCore->getSP_el(1);
+  }
 
   virtual void writefn(uArchARM *aCore, uint64_t aVal) override {
     aCore->setSP_el(1, aVal);
   }
 
-} SP_EL1_;
+  SP_EL1_()
+      : SysRegInfo("SP_EL1", SP_EL1_::state, SP_EL1_::type, SP_EL1_::opc0, SP_EL1_::opc1,
+                   SP_EL1_::opc2, SP_EL1_::crn, SP_EL1_::crm, SP_EL1_::access) {
+  }
+};
 
-struct SPSel : public SysRegInfo {
+class SPSel_ : public SysRegInfo {
+public:
   std::string name = "SPSel";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 0;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 2;
-  eAccessRight access = kPL1_RW;
-  eRegInfo type = kARM_NO_RAW;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 0;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 2;
+  static const eAccessRight access = kPL1_RW;
+  static const eRegInfo type = kARM_NO_RAW;
   uint64_t resetvalue = -1;
 
   /*spsel_read*/
@@ -361,110 +432,137 @@ struct SPSel : public SysRegInfo {
 
     aCore->setSP_el(cur_el, aVal);
   }
-} SPSel_;
 
-struct SPSR_IRQ : public SysRegInfo {
+  SPSel_()
+      : SysRegInfo("SPSel", SPSel_::state, SPSel_::type, SPSel_::opc0, SPSel_::opc1, SPSel_::opc2,
+                   SPSel_::crn, SPSel_::crm, SPSel_::access) {
+  }
+};
+
+class SPSR_IRQ_ : public SysRegInfo {
+public:
   std::string name = "SPSR_IRQ";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 4;
-  uint8_t opc2 = 0;
-  uint8_t crn = 4;
-  uint8_t crm = 3;
-  eAccessRight access = kPL2_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 4;
+  static const uint8_t opc2 = 0;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 3;
+  static const eAccessRight access = kPL2_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
 
-} SPSR_IRQ_;
+  SPSR_IRQ_()
+      : SysRegInfo("SPSR_IRQ", SPSR_IRQ_::state, SPSR_IRQ_::type, SPSR_IRQ_::opc0, SPSR_IRQ_::opc1,
+                   SPSR_IRQ_::opc2, SPSR_IRQ_::crn, SPSR_IRQ_::crm, SPSR_IRQ_::access) {
+  }
+};
 
-struct SPSR_ABT : public SysRegInfo {
+class SPSR_ABT_ : public SysRegInfo {
+public:
   std::string name = "SPSR_IRQ";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 4;
-  uint8_t opc2 = 1;
-  uint8_t crn = 4;
-  uint8_t crm = 3;
-  eAccessRight access = kPL2_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 4;
+  static const uint8_t opc2 = 1;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 3;
+  static const eAccessRight access = kPL2_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
 
-} SPSR_ABT_;
+  SPSR_ABT_()
+      : SysRegInfo("SPSR_ABT", SPSR_ABT_::state, SPSR_ABT_::type, SPSR_ABT_::opc0, SPSR_ABT_::opc1,
+                   SPSR_ABT_::opc2, SPSR_ABT_::crn, SPSR_ABT_::crm, SPSR_ABT_::access) {
+  }
+};
 
-struct SPSR_UND : public SysRegInfo {
+class SPSR_UND_ : public SysRegInfo {
+public:
   std::string name = "SPSR_UND";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 4;
-  uint8_t opc2 = 2;
-  uint8_t crn = 4;
-  uint8_t crm = 3;
-  eAccessRight access = kPL2_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 4;
+  static const uint8_t opc2 = 2;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 3;
+  static const eAccessRight access = kPL2_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
 
-} SPSR_UND_;
+  SPSR_UND_()
+      : SysRegInfo("SPSR_UND", SPSR_UND_::state, SPSR_UND_::type, SPSR_UND_::opc0, SPSR_UND_::opc1,
+                   SPSR_UND_::opc2, SPSR_UND_::crn, SPSR_UND_::crm, SPSR_UND_::access) {
+  }
+};
 
-struct SPSR_FIQ : public SysRegInfo {
+class SPSR_FIQ_ : public SysRegInfo {
+public:
   std::string name = "SPSR_FIQ";
-  eRegExecutionState state = kARM_STATE_AA64;
-  uint8_t opc0 = 3;
-  uint8_t opc1 = 4;
-  uint8_t opc2 = 3;
-  uint8_t crn = 4;
-  uint8_t crm = 3;
-  eAccessRight access = kPL2_RW;
-  eRegInfo type = kARM_ALIAS;
+  static const eRegExecutionState state = kARM_STATE_AA64;
+  static const uint8_t opc0 = 3;
+  static const uint8_t opc1 = 4;
+  static const uint8_t opc2 = 3;
+  static const uint8_t crn = 4;
+  static const uint8_t crm = 3;
+  static const eAccessRight access = kPL2_RW;
+  static const eRegInfo type = kARM_ALIAS;
   uint64_t resetvalue = -1;
 
-} SPSR_FIQ_;
+  SPSR_FIQ_()
+      : SysRegInfo("SPSR_FIQ", SPSR_FIQ_::state, SPSR_FIQ_::type, SPSR_FIQ_::opc0, SPSR_FIQ_::opc1,
+                   SPSR_FIQ_::opc2, SPSR_FIQ_::crn, SPSR_FIQ_::crm, SPSR_FIQ_::access) {
+  }
+};
 
-struct INVALID_PRIV : public SysRegInfo {
+class INVALID_PRIV_ : public SysRegInfo {
+public:
   std::string name = "INVALID_PRIV";
-
-} INVALID_PRIV_;
+};
 
 static std::vector<std::pair<std::array<uint8_t, 5>, ePrivRegs>> supported_sysRegs = {
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {NZCV_.opc0, NZCV_.opc1, NZCV_.opc2, NZCV_.crn, NZCV_.crm}, kNZCV),
+        {NZCV_::opc0, NZCV_::opc1, NZCV_::opc2, NZCV_::crn, NZCV_::crm}, kNZCV),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {DAIF_.opc0, DAIF_.opc1, DAIF_.opc2, DAIF_.crn, DAIF_.crm}, kDAIF),
+        {DAIF_::opc0, DAIF_::opc1, DAIF_::opc2, DAIF_::crn, DAIF_::crm}, kDAIF),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {TPIDR_EL0_.opc0, TPIDR_EL0_.opc1, TPIDR_EL0_.opc2, TPIDR_EL0_.crn, TPIDR_EL0_.crm},
+        {TPIDR_EL0_::opc0, TPIDR_EL0_::opc1, TPIDR_EL0_::opc2, TPIDR_EL0_::crn, TPIDR_EL0_::crm},
         kTPIDR_EL0),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {FPCR_.opc0, FPCR_.opc1, FPCR_.opc2, FPCR_.crn, FPCR_.crm}, kFPCR),
+        {FPCR_::opc0, FPCR_::opc1, FPCR_::opc2, FPCR_::crn, FPCR_::crm}, kFPCR),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {FPSR_.opc0, FPSR_.opc1, FPSR_.opc2, FPSR_.crn, FPSR_.crm}, kFPSR),
+        {FPSR_::opc0, FPSR_::opc1, FPSR_::opc2, FPSR_::crn, FPSR_::crm}, kFPSR),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {DCZID_EL0_.opc0, DCZID_EL0_.opc1, DCZID_EL0_.opc2, DCZID_EL0_.crn, DCZID_EL0_.crm},
+        {DCZID_EL0_::opc0, DCZID_EL0_::opc1, DCZID_EL0_::opc2, DCZID_EL0_::crn, DCZID_EL0_::crm},
         kDCZID_EL0),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {DC_ZVA_.opc0, DC_ZVA_.opc1, DC_ZVA_.opc2, DC_ZVA_.crn, DC_ZVA_.crm}, kDC_ZVA),
+        {DC_ZVA_::opc0, DC_ZVA_::opc1, DC_ZVA_::opc2, DC_ZVA_::crn, DC_ZVA_::crm}, kDC_ZVA),
+    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>({CURRENT_EL_::opc0, CURRENT_EL_::opc1,
+                                                       CURRENT_EL_::opc2, CURRENT_EL_::crn,
+                                                       CURRENT_EL_::crm},
+                                                      kCURRENT_EL),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {CURRENT_EL_.opc0, CURRENT_EL_.opc1, CURRENT_EL_.opc2, CURRENT_EL_.crn, CURRENT_EL_.crm},
-        kCURRENT_EL),
+        {ELR_EL1_::opc0, ELR_EL1_::opc1, ELR_EL1_::opc2, ELR_EL1_::crn, ELR_EL1_::crm}, kELR_EL1),
     std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {ELR_EL1_.opc1, ELR_EL1_.opc1, ELR_EL1_.opc2, ELR_EL1_.crn, ELR_EL1_.crm}, kELR_EL1),
+        {SPSR_EL1_::opc0, SPSR_EL1_::opc1, SPSR_EL1_::opc2, SPSR_EL1_::crn, SPSR_EL1_::crm},
+        kSPSR_EL1),
+    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
+        {SP_EL0_::opc0, SP_EL0_::opc1, SP_EL0_::opc2, SP_EL0_::crn, SP_EL0_::crm}, kSP_EL0),
+    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
+        {SP_EL1_::opc0, SP_EL1_::opc1, SP_EL1_::opc2, SP_EL1_::crn, SP_EL1_::crm}, kSP_EL1),
+    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
+        {SPSel_::opc0, SPSel_::opc1, SPSel_::opc2, SPSel_::crn, SPSel_::crm}, kSPSel),
+    // std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
+    //    {MDSCR_EL1_::opc0, MDSCR_EL1_::opc1, MDSCR_EL1_::opc2, MDSCR_EL1_::crn, MDSCR_EL1_::crm},
+    //    kMDSCR_EL1) std::make_pair<std::array<uint8_t, 5>, ePrivRegs>( {SPSR_IRQ_::opc0,
+    //    SPSR_IRQ_::opc1, SPSR_IRQ_::opc2, SPSR_IRQ_::crn, SPSR_IRQ_::crm},  kSPSR_IRQ),
+    //    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>( {SPSR_ABT_::opc0, SPSR_ABT_::opc1,
+    //    SPSR_ABT_::opc2, SPSR_ABT_::crn, SPSR_ABT_::crm},  kSPSR_ABT),
     //    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-    //    {SPSR_EL1_.opc0, SPSR_EL1_.opc1, SPSR_EL1_.opc2, SPSR_EL1_.crn,
-    //    SPSR_EL1_.crm},  kSPSR_EL1),
-    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {SP_EL0_.opc0, SP_EL0_.opc1, SP_EL0_.opc2, SP_EL0_.crn, SP_EL0_.crm}, kSP_EL0),
-    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {SP_EL1_.opc0, SP_EL1_.opc1, SP_EL1_.opc2, SP_EL1_.crn, SP_EL1_.crm}, kSP_EL1),
-    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-        {SPSel_.opc0, SPSel_.opc1, SPSel_.opc2, SPSel_.crn, SPSel_.crm}, kSPSel)
-    //    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-    //    {SPSR_IRQ_.opc0, SPSR_IRQ_.opc1, SPSR_IRQ_.opc2, SPSR_IRQ_.crn,
-    //    SPSR_IRQ_.crm},  kSPSR_IRQ), std::make_pair<std::array<uint8_t,
-    //    5>, ePrivRegs>( {SPSR_ABT_.opc0, SPSR_ABT_.opc1, SPSR_ABT_.opc2,
-    //    SPSR_ABT_.crn, SPSR_ABT_.crm},  kSPSR_ABT),
-    //    std::make_pair<std::array<uint8_t, 5>, ePrivRegs>(
-    //    {SPSR_UND_.opc0, SPSR_UND_.opc1, SPSR_UND_.opc2, SPSR_UND_.crn,
-    //    SPSR_UND_.crm},  kSPSR_UND), std::make_pair<std::array<uint8_t,
-    //    5>, ePrivRegs>( {SPSR_FIQ_.opc0, SPSR_FIQ_.opc1, SPSR_FIQ_.opc2,
-    //    SPSR_FIQ_.crn, SPSR_FIQ_.crm},  kSPSR_FIQ)
+    //    {SPSR_UND_::opc0, SPSR_UND_::opc1, SPSR_UND_::opc2, SPSR_UND_::crn,
+    //    SPSR_UND_::crm},  kSPSR_UND), std::make_pair<std::array<uint8_t,
+    //    5>, ePrivRegs>( {SPSR_FIQ_::opc0, SPSR_FIQ_::opc1, SPSR_FIQ_::opc2,
+    //    SPSR_FIQ_::crn, SPSR_FIQ_::crm},  kSPSR_FIQ)
 };
 
 ePrivRegs getPrivRegType(const uint8_t op0, const uint8_t op1, const uint8_t op2, const uint8_t crn,
@@ -478,49 +576,51 @@ ePrivRegs getPrivRegType(const uint8_t op0, const uint8_t op1, const uint8_t op2
   return kLastPrivReg;
 }
 
-SysRegInfo &getPriv(ePrivRegs aCode) {
+std::unique_ptr<SysRegInfo> getPriv(ePrivRegs aCode) {
   switch (aCode) {
   case kNZCV:
-    return NZCV_;
+    return std::make_unique<NZCV_>();
   case kDAIF:
-    return DAIF_;
+    return std::make_unique<DAIF_>();
   case kFPCR:
-    return FPCR_;
+    return std::make_unique<FPCR_>();
   case kFPSR:
-    return FPSR_;
+    return std::make_unique<FPSR_>();
   case kDCZID_EL0:
-    return DCZID_EL0_;
+    return std::make_unique<DCZID_EL0_>();
   case kDC_ZVA:
-    return DC_ZVA_;
+    return std::make_unique<DC_ZVA_>();
   case kCURRENT_EL:
-    return CURRENT_EL_;
+    return std::make_unique<CURRENT_EL_>();
   case kELR_EL1:
-    return ELR_EL1_;
+    return std::make_unique<ELR_EL1_>();
   case kSPSR_EL1:
-    return SPSR_EL1_;
+    return std::make_unique<SPSR_EL1_>();
   case kSP_EL0:
-    return SP_EL0_;
+    return std::make_unique<SP_EL0_>();
   case kSP_EL1:
-    return SP_EL1_;
+    return std::make_unique<SP_EL1_>();
   case kSPSel:
-    return SPSel_;
+    return std::make_unique<SPSel_>();
   case kSPSR_IRQ:
-    return SPSR_IRQ_;
+    return std::make_unique<SPSR_IRQ_>();
   case kSPSR_ABT:
-    return SPSR_ABT_;
+    return std::make_unique<SPSR_ABT_>();
   case kSPSR_UND:
-    return SPSR_UND_;
+    return std::make_unique<SPSR_UND_>();
   case kSPSR_FIQ:
-    return SPSR_FIQ_;
+    return std::make_unique<SPSR_FIQ_>();
   case kTPIDR_EL0:
-    return TPIDR_EL0_;
-  default:
-    DBG_Assert(false, (<< "Unimplemented SysReg Code" << aCode));
-    return INVALID_PRIV_;
+    return std::make_unique<TPIDR_EL0_>();
+  default: // FIXME: Only return default/abstract if implemented by QEMU
+    return std::make_unique<SysRegInfo>();
+    // DBG_Assert(false, (<< "Unimplemented SysReg Code" << aCode));
+    // return INVALID_PRIV_;
   }
 }
 
-SysRegInfo &getPriv(uint8_t op0, uint8_t op1, uint8_t op2, uint8_t crn, uint8_t crm) {
+std::unique_ptr<SysRegInfo> getPriv(uint8_t op0, uint8_t op1, uint8_t op2, uint8_t crn,
+                                    uint8_t crm) {
   ePrivRegs r = getPrivRegType(op0, op1, op2, crn, crm);
   return getPriv(r);
 }

--- a/components/uArchARM/uArchInterfaces.hpp
+++ b/components/uArchARM/uArchInterfaces.hpp
@@ -81,7 +81,7 @@ struct BranchFeedback;
 
 namespace nuArchARM {
 
-struct SysRegInfo;
+class SysRegInfo; // MARK: forward declare
 
 using namespace Flexus::SharedTypes;
 
@@ -237,12 +237,10 @@ enum ePrivRegs {
   kSPSR_UND,
   kSPSR_FIQ,
   kTPIDR_EL0,
+  kAbstractSysReg, /* Msutherl: Blanket type for all registers to represent as hashed/encoded
+                      5-tuple which are then read through QEMU */
   kLastPrivReg
 };
-
-SysRegInfo &getPriv(ePrivRegs aCode);
-ePrivRegs getPrivRegType(const uint8_t op0, const uint8_t op1, const uint8_t op2, const uint8_t crn,
-                         const uint8_t crm);
 
 enum eAccessResult {
   /* Access is permitted */
@@ -893,11 +891,6 @@ struct uArchARM {
     DBG_Assert(false);
     return SCTLR_EL(0);
   }
-  virtual SysRegInfo &getSysRegInfo(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t CRn,
-                                    uint8_t CRm) {
-    DBG_Assert(false);
-    return getPriv(kLastPrivReg);
-  }
   virtual void increaseEL() {
     DBG_Assert(false);
   }
@@ -1010,7 +1003,6 @@ struct uArchARM {
   virtual void setDAIF(uint32_t aDAIF) {
     DBG_Assert(false);
   }
-
   virtual Flexus::Qemu::API::exception_t getException() {
     DBG_Assert(false);
     return Flexus::Qemu::API::exception_t();
@@ -1104,12 +1096,21 @@ struct uArchARM {
     DBG_Assert(false);
     return false;
   }
+
+  /* Msutherl: API to read system register encoding and system register value */
+  virtual uint64_t readUnhashedSysReg(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn,
+                                      uint8_t crm) {
+    DBG_Assert(false);
+    return 0;
+  }
 };
 
 static const PhysicalMemoryAddress kInvalid(0);
 static const VirtualMemoryAddress kUnresolved(-1);
 
 } // namespace nuArchARM
+
+#include <components/uArchARM/systemRegister.hpp> // MARK
 
 namespace Flexus {
 namespace SharedTypes {

--- a/core/qemu/api.cpp
+++ b/core/qemu/api.cpp
@@ -54,6 +54,7 @@ QEMU_GET_PENDING_INTERRUPT_PROC QEMU_get_pending_interrupt = nullptr;
 
 QEMU_WRITE_REGISTER_PROC QEMU_write_register = nullptr;
 QEMU_READ_REGISTER_PROC QEMU_read_register = nullptr;
+QEMU_READ_UNHASHED_SYSREG_PROC QEMU_read_unhashed_sysreg = nullptr;
 QEMU_READ_PSTATE_PROC QEMU_read_pstate = nullptr;
 QEMU_READ_FPCR_PROC QEMU_read_fpcr = nullptr;
 QEMU_READ_FPSR_PROC QEMU_read_fpsr = nullptr;
@@ -106,6 +107,7 @@ void QFLEX_API_set_Interface_Hooks(const QFLEX_API_Interface_Hooks_t *hooks) {
   QEMU_clear_exception = hooks->QEMU_clear_exception;
   QEMU_write_register = hooks->QEMU_write_register;
   QEMU_read_register = hooks->QEMU_read_register;
+  QEMU_read_unhashed_sysreg = hooks->QEMU_read_unhashed_sysreg;
   QEMU_cpu_has_work = hooks->QEMU_cpu_has_work;
 
   QEMU_read_fpcr = hooks->QEMU_read_fpcr;

--- a/core/qemu/mai_api.hpp
+++ b/core/qemu/mai_api.hpp
@@ -281,6 +281,11 @@ public:
   bool mai_mode() const {
     return true;
   }
+
+  uint64_t read_sysreg_from_qemu(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn,
+                                 uint8_t crm) {
+    return API::QEMU_read_unhashed_sysreg(*this, opc0, opc1, opc2, crn, crm);
+  }
 };
 
 class armProcessorImpl : public BaseProcessorImpl {


### PR DESCRIPTION
1) Adds general system register interface with following features:
- uses SysRegInfo as an abstract base class, which uses the sysreg
  encoding (opc0,opc1,opc2,crn,crm) as a 5-tuple to encode the register
  name and type.
- Accesses to such registers are redirected to QEMU itself, which
decodes the 5-tuple and returns the register value.
IMPORTANT: This interface is restricted to registers which do not have
the flag "ARM_CP_NO_RAW" set (see libqflex's api.c). Those registers are
actual internal state-machines in QEMU and cannot be simply read without
changing the emulator state.

2) Refactors system registers to proper classes and not structs with
interfaces (they were basically classes anyway)