### PR TITLE
Enhance MMU functionality and fix bugs

### DIFF
--- a/components/DecoupledFeederQEMU/QemuTracer.cpp
+++ b/components/DecoupledFeederQEMU/QemuTracer.cpp
@@ -305,6 +305,7 @@ public:
     theMemoryMessage.address() = PhysicalMemoryAddress(mem_trans->s.physical_address);
     theMemoryMessage.pc() = VirtualMemoryAddress(mem_trans->s.logical_address);
     theMemoryMessage.priv() = IS_PRIV(mem_trans);
+    theMemoryMessage.coreIdx() = theIndex;
 
     // Set the type field of the memory operation
     if (mem_trans->s.atomic) {

--- a/components/MMU/MMUImpl.cpp
+++ b/components/MMU/MMUImpl.cpp
@@ -216,8 +216,8 @@ public:
 
   void saveState(std::string const &aDirName) {
     std::ofstream iFile, dFile;
-    iFile.open(aDirName + "/iTLBout", std::ofstream::out | std::ofstream::app);
-    dFile.open(aDirName + "/dTLBout", std::ofstream::out | std::ofstream::app);
+    iFile.open(aDirName + "/" + statName() + "-itlb", std::ofstream::out | std::ofstream::app);
+    dFile.open(aDirName + "/" + statName() + "-dtlb", std::ofstream::out | std::ofstream::app);
 
     boost::archive::text_oarchive ioarch(iFile);
     boost::archive::text_oarchive doarch(dFile);
@@ -231,8 +231,8 @@ public:
 
   void loadState(std::string const &aDirName) {
     std::ifstream iFile, dFile;
-    iFile.open(aDirName + "/iTLBout", std::ifstream::in);
-    dFile.open(aDirName + "/dTLBout", std::ifstream::in);
+    iFile.open(aDirName + "/" + statName() + "-itlb", std::ifstream::in);
+    dFile.open(aDirName + "/" + statName() + "-dtlb", std::ifstream::in);
 
     boost::archive::text_iarchive iiarch(iFile);
     boost::archive::text_iarchive diarch(dFile);

--- a/components/MMU/MMUImpl.cpp
+++ b/components/MMU/MMUImpl.cpp
@@ -175,6 +175,14 @@ private:
       theSize = aSize;
     }
 
+    size_t capacity() {
+      return theSize;
+    }
+
+    void clear() {
+      theTLB.clear();
+    }
+
     size_t size() {
       return theTLB.size();
     }
@@ -240,9 +248,21 @@ public:
     boost::archive::text_iarchive iiarch(iFile);
     boost::archive::text_iarchive diarch(dFile);
 
+    uint64_t iSize = theInstrTLB.capacity();
+    uint64_t dSize = theDataTLB.capacity();
     iiarch >> theInstrTLB;
     diarch >> theDataTLB;
-    DBG_(Dev, (<< "Entries - iTLB:" << theInstrTLB.size() << ", dTLB:" << theDataTLB.size()));
+    if (iSize != theInstrTLB.capacity()) {
+      theInstrTLB.clear();
+      theInstrTLB.resize(iSize);
+      DBG_(Dev, (<< "Changing iTLB capacity from " << theInstrTLB.capacity() << " to " << iSize));
+    }
+    if (dSize != theDataTLB.capacity()) {
+      theDataTLB.clear();
+      theDataTLB.resize(dSize);
+      DBG_(Dev, (<< "Changing dTLB capacity from " << theInstrTLB.capacity() << " to " << iSize));
+    }
+    DBG_(Dev, (<< "Size - iTLB:" << theInstrTLB.capacity() << ", dTLB:" << theDataTLB.capacity()));
 
     iFile.close();
     dFile.close();

--- a/components/MMU/MMUImpl.cpp
+++ b/components/MMU/MMUImpl.cpp
@@ -94,7 +94,7 @@ namespace nMMU {
 using namespace Flexus;
 using namespace Core;
 using namespace SharedTypes;
-#define PAGEMASK ~0xFFFULL
+uint64_t PAGEMASK;
 
 class FLEXUS_COMPONENT(MMU) {
   FLEXUS_COMPONENT_IMPL(MMU);
@@ -421,6 +421,9 @@ public:
     }
     theMMU->initRegsFromQEMUObject(getMMURegsFromQEMU(anIndex));
     theMMU->setupAddressSpaceSizesAndGranules();
+    DBG_Assert(theMMU->Gran0->getlogKBSize() == 12, (<< "TG0 has non-4KB size - unsupported"));
+    DBG_Assert(theMMU->Gran1->getlogKBSize() == 12, (<< "TG1 has non-4KB size - unsupported"));
+    PAGEMASK = ~((1 << theMMU->Gran0->getlogKBSize()) - 1);
     if (thePageWalker) {
       DBG_(VVerb, (<< "Annulling all PW entries"));
       thePageWalker->annulAll();
@@ -535,6 +538,9 @@ public:
         theMMU.reset(new mmu_t());
         theMMU->initRegsFromQEMUObject(getMMURegsFromQEMU((int)flexusIndex()));
         theMMU->setupAddressSpaceSizesAndGranules();
+        DBG_Assert(theMMU->Gran0->getlogKBSize() == 12, (<< "TG0 has non-4KB size - unsupported"));
+        DBG_Assert(theMMU->Gran1->getlogKBSize() == 12, (<< "TG1 has non-4KB size - unsupported"));
+        PAGEMASK = ~((1 << theMMU->Gran0->getlogKBSize()) - 1);
         thePageWalker->setMMU(theMMU);
         theMMUInitialized = true;
       }


### PR DESCRIPTION
1. Add component index number to MMU checkpoint filename, allowing saving multicore TLB structures.
2. Add MMU stats (trace mode), rectify order of memory accesses with MMU, enforce 4KB pages in trace mode.
3. Enable tracking TLB capacity, and changing it while loading checkpoints.