### PR TITLE
Fix address translation and opcode updates in frontend

### DIFF
--- a/components/CommonQEMU/Translation.hpp
+++ b/components/CommonQEMU/Translation.hpp
@@ -47,6 +47,7 @@
 #include <components/CommonQEMU/Slices/AbstractInstruction.hpp>
 #include <core/boost_extensions/intrusive_ptr.hpp>
 #include <core/debug/debug.hpp>
+#include <functional>
 
 namespace Flexus {
 namespace SharedTypes {
@@ -222,6 +223,19 @@ struct Translation : public boost::counted_base {
 };
 
 typedef boost::intrusive_ptr<Translation> TranslationPtr;
+
+// MARK: Specialization of hasher and equality operator for translation object
+struct TranslationPtrHasher {
+  std::size_t operator()(const TranslationPtr &transPtr) const {
+    return transPtr->theID;
+  }
+};
+
+struct TranslationPtrEqualityCheck {
+  bool operator()(const TranslationPtr &lhs, const TranslationPtr &rhs) const {
+    return (lhs->theID == rhs->theID) && (lhs->theVaddr == rhs->theVaddr);
+  }
+};
 
 } // namespace SharedTypes
 } // namespace Flexus

--- a/components/uFetch/uFetchImpl.cpp
+++ b/components/uFetch/uFetchImpl.cpp
@@ -235,11 +235,12 @@ class FLEXUS_COMPONENT(uFetch) {
   //       MANDATORY because two FetchedOpcs can have same PC but indep. TranslationPtrs
   //       Also, any MMU transaction can complete out of order (in general)
   typedef std::list<FetchedOpcode>::iterator opcodeQIterator;
-  std::unordered_map<TranslationPtr, opcodeQIterator, // K/V
-                     TranslationPtrHasher,            // Custom hash object
-                     TranslationPtrEqualityCheck      // Custom equality comparison
-                     >
-      tr_op_bijection;
+  typedef std::unordered_map<TranslationPtr, opcodeQIterator, // K/V
+                             TranslationPtrHasher,            // Custom hash object
+                             TranslationPtrEqualityCheck      // Custom equality comparison
+                             >
+      BijectionMapType_t;
+  BijectionMapType_t tr_op_bijection;
 
   typedef std::unordered_set<TranslationPtr,             // Key
                              TranslationPtrHasher,       // Custom hash
@@ -994,8 +995,8 @@ private:
     xlat->setInstr();
 
     // Insert an entry into the translation<->opcode map and outstanding translations expected
-    std::pair<std::unordered_map<TranslationPtr, opcodeQIterator>::iterator, bool>
-        bijection_insertion = tr_op_bijection.insert(std::make_pair(xlat, newOpcIterator));
+    std::pair<BijectionMapType_t::iterator, bool> bijection_insertion =
+        tr_op_bijection.insert(std::make_pair(xlat, newOpcIterator));
     DBG_(TR_BIJ_DBG, Comp(*this)(<< "Inserting xlat objection with vaddr " << xlat->theVaddr
                                  << " pointing to PC " << newOpcIterator->thePC
                                  << " into waitingForOpcodesQueue bijection "));
@@ -1044,8 +1045,7 @@ private:
     }
     uint32_t opcode = 1;
     // MARK: Look up in the opc bijection and get the correct index
-    std::unordered_map<TranslationPtr, opcodeQIterator>::iterator bijection_iter =
-        tr_op_bijection.find(tr);
+    BijectionMapType_t::iterator bijection_iter = tr_op_bijection.find(tr);
     DBG_AssertSev(Crit, bijection_iter != tr_op_bijection.end(),
                   Comp(*this)(<< "ERROR: Opcode index was NOT found for translationPtr with ID"
                               << tr->theID << " and address" << tr->theVaddr));

--- a/components/uFetch/uFetchTypes.hpp
+++ b/components/uFetch/uFetchTypes.hpp
@@ -148,60 +148,26 @@ struct FetchBundle : public boost::counted_base {
   std::list<tFillLevel> theFillLevels;
   int32_t coreID;
 
-  void updateOpcode(VirtualMemoryAddress anAddress, Opcode anOpcode) {
-    for (FetchedOpcode &i : theOpcodes) {
-      DBG_(Iface, (<< "comparing entries " << anAddress << " with " << i.thePC));
-
-      if (i.thePC == anAddress) {
-        i.theOpcode = anOpcode;
-        return;
-      }
-    }
-    DBG_(Iface, (<< "didnt find opcode entry for " << anAddress));
-    DBG_Assert(false);
+  void updateOpcode(VirtualMemoryAddress anAddress, std::list<FetchedOpcode>::iterator it,
+                    Opcode anOpcode) {
+    DBG_AssertSev(Crit, it->thePC == anAddress,
+                  (<< "ERROR: FetchedOpcode iterator did not match!! Iterator PC " << it->thePC
+                   << ", translation returned vaddr " << anAddress));
+    it->theOpcode = anOpcode;
   }
 
   void clear() {
-    for (auto &i : theOpcodes) {
-      DBG_(Iface, (<< "deleting opcode entry for " << i.thePC));
-    }
     theOpcodes.clear();
     theFillLevels.clear();
   }
 };
 
+typedef boost::intrusive_ptr<FetchBundle> pFetchBundle;
+
 struct CPUState {
   int32_t theTL;
   int32_t thePSTATE;
 };
-
-typedef boost::intrusive_ptr<FetchBundle> pFetchBundle;
-
-struct TranslationVecWrapper : public boost::counted_base {
-
-  TranslationVecWrapper() {
-  }
-  ~TranslationVecWrapper() {
-  }
-
-  std::queue<TranslationPtr> internalContainer; // from mai_api
-
-  void addNewTranslation(boost::intrusive_ptr<Translation> &aTr) {
-    internalContainer.push(aTr);
-  }
-
-  //    void updateExistingTranslation(VirtualMemoryAddress aVAddr,
-  //    PhysicalMemoryAddress translatedAddress) {
-  //        for( auto& translation : internalContainer ) {
-  //            if( translation->theVaddr == aVAddr ) {
-  //                translation->thePaddr = translatedAddress;
-  //                return;
-  //            }
-  //        }
-  //    }
-};
-
-typedef boost::intrusive_ptr<TranslationVecWrapper> TranslatedAddresses;
 
 } // end namespace SharedTypes
 } // end namespace Flexus


### PR DESCRIPTION
Corrects the case where multiple PCs were simultaneously blocking on V->P translations (e.g., in a loop)