### PR TITLE
Fixes to fetch lookup and post-fetch queue logic.

### DIFF
--- a/components/uFetch/uFetchImpl.cpp
+++ b/components/uFetch/uFetchImpl.cpp
@@ -896,8 +896,7 @@ private:
       return;
     }
 
-    if (waitingForOpcodeQueue->theOpcodes.size() < theMissQueueSize && available_fiq > 0 &&
-        (theFAQ[anIndex].size() > 0 || theFlexus->quiescing())) {
+    if (available_fiq > 0 && (theFAQ[anIndex].size() > 0 || theFlexus->quiescing())) {
       std::set<VirtualMemoryAddress> available_lines;
       FETCH_DBG("starting to process the fetches..." << remaining_fetch);
 


### PR DESCRIPTION
- Remove check where `waitingForOpcodeQueue` compares its size to missQueue. theMissQueue is the outstanding number of prefetches, not lookups.
- Add check in `processBundle()` so that the number of fetched/aligned instructions does not over-run the decoder's FIQ.