### PR TITLE
Added correct initialization code in JumpTables.

### DIFF
--- a/core/interface_macros.hpp
+++ b/core/interface_macros.hpp
@@ -169,9 +169,9 @@
    BOOST_PP_TUPLE_ELEM(FLEXUS_i_IT_LEN, FLEXUS_i_IT_Width, ParameterTuple)) /**/
 
 #define FLEXUS_IFACE_JUMPTABLE_Impl(Name)                                                          \
-  bool (*BOOST_PP_CAT(wire_available_, Name))(Flexus::Core::index_t anIndex);                      \
+  bool (*BOOST_PP_CAT(wire_available_, Name))(Flexus::Core::index_t anIndex) = 0;	           \
   void (*BOOST_PP_CAT(wire_manip_, Name))(Flexus::Core::index_t anIndex,                           \
-                                          iface::Name::payload & aPayload); /**/
+                                          iface::Name::payload & aPayload) = 0; /**/
 
 #define FLEXUS_IFACE_JUMPTABLE_PullInput(Name) FLEXUS_IFACE_JUMPTABLE_Impl(Name)          /**/
 #define FLEXUS_IFACE_JUMPTABLE_PullInputArray(Name) FLEXUS_IFACE_JUMPTABLE_Impl(Name)     /**/

--- a/core/interface_macros.hpp
+++ b/core/interface_macros.hpp
@@ -169,7 +169,7 @@
    BOOST_PP_TUPLE_ELEM(FLEXUS_i_IT_LEN, FLEXUS_i_IT_Width, ParameterTuple)) /**/
 
 #define FLEXUS_IFACE_JUMPTABLE_Impl(Name)                                                          \
-  bool (*BOOST_PP_CAT(wire_available_, Name))(Flexus::Core::index_t anIndex) = 0;	           \
+  bool (*BOOST_PP_CAT(wire_available_, Name))(Flexus::Core::index_t anIndex) = 0;                  \
   void (*BOOST_PP_CAT(wire_manip_, Name))(Flexus::Core::index_t anIndex,                           \
                                           iface::Name::payload & aPayload) = 0; /**/
 


### PR DESCRIPTION
Both manipulate and available functions are now initialized to 0.
This makes the JumpTable consistent with get_channel << operator API.
It is now safe to send data over unconnected channels.

On branch fix-JumpTable-funcptr-init
Changes to be committed:
	modified:   core/interface_macros.hpp

Before these changes, sending data over unconnected channel resulted in undefined behavior.
The reason for this was that the << operator checks if a function pointer is valid before calling it. This check is an equality comparison with 0. However, the JumpTable fails to initialize the function pointers with null, resulting in undefined behavior,
When a component tries to send data over an unconnected channel, if the function pointers for that channel hold random pointers, the check in the << operator passes, which leads to a jump to some random location.

With this fix, the JumpTable will initialize the function pointers to 0 by default. Therefore, if a channel is left unconnected, the check in the operator is guaranteed to fail.
