### PR TITLE
fix: CRC instruction operands

### DIFF
--- a/components/Decoder/SemanticActions.hpp
+++ b/components/Decoder/SemanticActions.hpp
@@ -263,6 +263,7 @@ crcAction(SemanticInstruction* anInstruction,
           eOperandCode anInputCode,
           eOperandCode anInputCode2,
           eOperandCode anOutputCode,
+          std::vector<std::list<InternalDependance>>& rs_deps,
           bool is64);
 predicated_action
 countAction(SemanticInstruction* anInstruction,

--- a/components/Decoder/encodings/DataProcReg.cpp
+++ b/components/Decoder/encodings/DataProcReg.cpp
@@ -190,7 +190,7 @@ CRC(archcode const& aFetchedOpcode, uint32_t aCPU, int64_t aSequenceNo)
     std::vector<std::list<InternalDependance>> rs_deps(2);
     uint32_t poly = crc32c ? 0x1EDC6F41 : 0x04C11DB7;
 
-    predicated_action act = crcAction(inst, poly, kOperand1, kOperand2, kResult, sf);
+    predicated_action act = crcAction(inst, poly, kOperand1, kOperand2, kResult, rs_deps, sf);
 
     readRegister(inst, 1, rn, rs_deps[0], false);
     readRegister(inst, 2, rm, rs_deps[1], sf);


### PR DESCRIPTION
This PR fixes the following problems of CRC:
- The dependency sanctification
- Improper initialized operand (`theInputCode2`)
- Wrong operand type