### PR TITLE
fix: remove EL2 support

### DIFF
--- a/components/MMU/pageWalk.cpp
+++ b/components/MMU/pageWalk.cpp
@@ -256,6 +256,14 @@ PageWalk::InitialTranslationSetup(TranslationTransport& aTranslation)
 
     uint8_t EL = statefulPointer->ELRegime;
 
+
+     /**
+      * Bryan Perdrizat
+      *      EL2 and EL3 are not setted up because QFlex is not (yet)
+      *      supporting well EL2 (hypervisor) mode well.
+      */
+    DBG_Assert(EL <= 1);
+
     // Handle a case where for Linux, the page table of EL0 is in EL1's register.
     if (EL == 0) {
         DBG_Assert(statefulPointer->isBR0);

--- a/components/uArch/CoreModel/construct.cpp
+++ b/components/uArch/CoreModel/construct.cpp
@@ -441,24 +441,28 @@ void
 CoreImpl::setSP_el(uint8_t anId, uint64_t aVal)
 {
     DBG_Assert(0 <= anId && anId < 4, (<< "Out of bound access with index = " << anId));
+    DBG_Assert(anId < 2, (<< "Unhandled simulation of hypervisor mode"));
     theSP_el[anId] = aVal;
 }
 uint64_t
 CoreImpl::getSP_el(uint8_t anId)
 {
     DBG_Assert(0 <= anId && anId < 4, (<< "Out of bound access with index = " << anId));
+    DBG_Assert(anId < 2, (<< "Unhandled simulation of hypervisor mode"));
     return theSP_el[anId];
 }
 void
 CoreImpl::setSPSR_el(uint8_t anId, uint64_t aVal)
 {
     DBG_Assert(0 <= anId && anId < 4, (<< "Out of bound access with index = " << anId));
+    DBG_Assert(anId < 2, (<< "Unhandled simulation of hypervisor mode"));
     theSPSR_EL[anId] = aVal;
 }
 uint64_t
 CoreImpl::getSPSR_el(uint8_t anId)
 {
     DBG_Assert(0 <= anId && anId < 4, (<< "Out of bound access with index = " << anId));
+    DBG_Assert(anId < 2, (<< "Unhandled simulation of hypervisor mode"));
     return theSPSR_EL[anId];
 }
 uint32_t
@@ -514,6 +518,7 @@ CoreImpl::setSCTLR_EL(uint8_t anId, uint64_t aSCTLR_EL)
 uint64_t
 CoreImpl::getSCTLR_EL(uint8_t anId)
 {
+    DBG_Assert(anId < 2, (<< "Unhandled simulation of hypervisor mode"));
     return theSCTLR_EL[anId];
 }
 void
@@ -524,7 +529,8 @@ CoreImpl::setHCREL2(uint64_t aHCREL2)
 uint64_t
 CoreImpl::getHCREL2()
 {
-    return theHCR_EL2;
+    DBG_Assert(false, (<< "Unhandled simulation of hypervisor mode"));
+    return 0;
 }
 void
 CoreImpl::setException(Flexus::Qemu::API::exception_t anEXP)

--- a/components/uArch/uArchInterfaces.hpp
+++ b/components/uArch/uArchInterfaces.hpp
@@ -191,7 +191,6 @@ enum ePrivRegs
     kSPSR_UND,
     kSPSR_FIQ,
     kTPIDR_EL0,
-    kTPIDR_EL2,
     kAbstractSysReg, /* Msutherl: Blanket type for all registers to represent as hashed/encoded
                         5-tuple which are then read through QEMU */
     kLastPrivReg


### PR DESCRIPTION
Setting virtualization=on in QEMU makes the kernel and the userspace program uses EL2 mode. This makes the address translation complicated.

EL2 was never properly supported by other components either. Removing it makes the design simple and clear.