### PR TITLE
fix: Stop assertion failure caused by speculative instructions.

### DIFF
--- a/components/MMU/pageWalk.cpp
+++ b/components/MMU/pageWalk.cpp
@@ -258,7 +258,8 @@ PageWalk::InitialTranslationSetup(TranslationTransport& aTranslation)
 
     // Handle a case where for Linux, the page table of EL0 is in EL1's register.
     if (EL == 0) {
-        DBG_Assert(statefulPointer->isBR0);
+        // There might be speculative memory accesses, so the following check may not be passed.
+        // DBG_Assert(statefulPointer->isBR0);
         EL = 1;
     };
 

--- a/components/uArch/CoreModel/arbiter.cpp
+++ b/components/uArch/CoreModel/arbiter.cpp
@@ -492,7 +492,8 @@ CoreImpl::scanAndBlockMSHR(memq_t::index<by_insn>::type::iterator anLSQEntry)
     // Check for an existing MSHR for the same address (issued this cycle)
     MSHRs_t::iterator existing = theMSHRs.find(anLSQEntry->thePaddr);
     if (existing != theMSHRs.end()) {
-        DBG_Assert(!existing->second.theWaitingLSQs.empty());
+        // Maybe the original load was a speculative load that was annulled
+        // DBG_Assert(!existing->second.theWaitingLSQs.empty());
         existing->second.theBlockedOps.push_back(anLSQEntry->theInstruction);
         return true;
     }


### PR DESCRIPTION
This PR provides a temporal solution.
A better way is to add a speculative flag to these instructions and do not check these assertions for these instructions.