### PR TITLE
chore: set the default watchdog timeout to 2000 cycles.

### DIFF
--- a/core/flexus.cpp
+++ b/core/flexus.cpp
@@ -137,7 +137,7 @@ class FlexusImpl : public FlexusInterface
 
   public:
     FlexusImpl(Qemu::API::conf_object_t* anObject)
-      : cpu_watchdog_timeout(1000)
+      : cpu_watchdog_timeout(2000)
       , theInitialized(false)
       , theCycleCount(0)
       , theStatInterval(100)


### PR DESCRIPTION
The previous threshold was 1000 cycles, and it is not enough for a special case: Resync -> instruction fetch causing page walks (including 5 cache misses) -> the load instruction itself cause page walk and 5 cache misses.