### PR TITLE
isPriv function is removed from instruction and added to the coreimpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,7 +333,6 @@ tags
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
-.cache
 
 # Local History for Visual Studio Code
 .history/

--- a/.gitignore
+++ b/.gitignore
@@ -333,6 +333,7 @@ tags
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+.cache
 
 # Local History for Visual Studio Code
 .history/

--- a/components/CommonQEMU/Slices/ArchitecturalInstruction.hpp
+++ b/components/CommonQEMU/Slices/ArchitecturalInstruction.hpp
@@ -47,7 +47,6 @@ class ArchitecturalInstruction : public boost::counted_base
     bool thePerformed;
     bool theCommitted;
     bool theSync;
-    bool thePriv;
     bool theShadow;
     bool theTrace; // a traced instruction
     bool theIsAtomic;
@@ -72,7 +71,6 @@ class ArchitecturalInstruction : public boost::counted_base
       , thePerformed(false)
       , theCommitted(false)
       , theSync(anOriginal->theSync)
-      , thePriv(anOriginal->thePriv)
       , theShadow(true)
       , theTrace(anOriginal->theTrace)
       , theStartTime(0)
@@ -97,7 +95,6 @@ class ArchitecturalInstruction : public boost::counted_base
       , thePerformed(false)
       , theCommitted(false)
       , theSync(false)
-      , thePriv(false)
       , theShadow(false)
       , theTrace(false)
       , theStartTime(0)
@@ -122,7 +119,6 @@ class ArchitecturalInstruction : public boost::counted_base
       , thePerformed(false)
       , theCommitted(false)
       , theSync(false)
-      , thePriv(false)
       , theShadow(false)
       , theTrace(false)
       , theIsAtomic(false)
@@ -152,7 +148,6 @@ class ArchitecturalInstruction : public boost::counted_base
     bool isRmw() const { return (theOperation == Rmw); }
     bool isMEMBAR() const { return (theOperation == Membar); }
     bool isSync() const { return theSync; }
-    bool isPriv() const { return thePriv; }
 
     bool isShadow() const { return theShadow; }
 
@@ -200,7 +195,6 @@ class ArchitecturalInstruction : public boost::counted_base
 
     // InorderInstructionImpl Interface functions
     void setSync() { theSync = true; }
-    void setPriv() { thePriv = true; }
 
     // Set operation types
     void setIsNop() { theOperation = Nop; }

--- a/components/Decoder/Instruction.cpp
+++ b/components/Decoder/Instruction.cpp
@@ -51,7 +51,6 @@ ArchInstruction::ArchInstruction(VirtualMemoryAddress aPC,
   , theUsesFpDiv(false)
   , theUsesFpSqrt(false)
   , theInsnSourceLevel(eL1I)
-  , thePriv(false)
 {
 }
 

--- a/components/Decoder/Instruction.hpp
+++ b/components/Decoder/Instruction.hpp
@@ -58,7 +58,6 @@ class ArchInstruction : public nuArch::Instruction
     bool theUsesFpDiv;
     bool theUsesFpSqrt;
     tFillLevel theInsnSourceLevel;
-    bool thePriv;
 
   public:
     virtual bool usesIntAlu() const;
@@ -245,9 +244,6 @@ class ArchInstruction : public nuArch::Instruction
 
     virtual VirtualMemoryAddress pcNext() const { return thePCReg; }
 
-    virtual bool isPriv() const { return thePriv; }
-    virtual void makePriv() { thePriv = true; }
-
     virtual bool isTrap() const { return theRaisedException != kException_None; }
     virtual boost::intrusive_ptr<BPredState> bpState() const { return theBPState; }
     bool isBranch() const { return theInstructionClass == clsBranch; }
@@ -320,7 +316,6 @@ class ArchInstruction : public nuArch::Instruction
       , theUsesFpDiv(false)
       , theUsesFpSqrt(false)
       , theInsnSourceLevel(eL1I)
-      , thePriv(false)
     {
     }
 

--- a/components/uArch/CoreModel/accounting.cpp
+++ b/components/uArch/CoreModel/accounting.cpp
@@ -196,7 +196,7 @@ CoreImpl::accountCommit(boost::intrusive_ptr<Instruction> anInstruction, bool aR
         level = 3 /* idle */;
     else if (anInstruction->isTrap())
         level = 2 /* trap */;
-    else if (anInstruction->isPriv())
+    else if (isPrivileged())
         level = 1 /* system */;
     int32_t spin = (theSpinning) ? 4 : 0;
 
@@ -383,7 +383,7 @@ CoreImpl::accountRetire(boost::intrusive_ptr<Instruction> anInst)
     if (theIsSpeculating) { ++theRetiresSinceCheckpoint; }
 
     // Determine cycle category (always based on last retire in cycle)
-    bool system = theROB.front()->isPriv();
+    bool system = isPrivileged();
 
     theIsIdle = Flexus::Qemu::Processor::getProcessor(theNode).is_busy() ? false : true;
 

--- a/components/uArch/CoreModel/arbiter.cpp
+++ b/components/uArch/CoreModel/arbiter.cpp
@@ -378,7 +378,7 @@ CoreImpl::issue(boost::intrusive_ptr<Instruction> anInstruction)
     op->theSize = mshr.theSize = lsq_entry->theSize;
     mshr.theWaitingLSQs.push_back(lsq_entry);
     op->thePC   = lsq_entry->theInstruction->pc();
-    bool system = lsq_entry->theInstruction->isPriv();
+    bool system = isPrivileged();
     if (lsq_entry->theValue) {
         op->theValue = *lsq_entry->theValue;
     } else {

--- a/components/uArch/CoreModel/construct.cpp
+++ b/components/uArch/CoreModel/construct.cpp
@@ -574,6 +574,11 @@ CoreImpl::setPC(uint64_t aPC)
     thePC = aPC;
 }
 
+bool CoreImpl::isPrivileged()
+{
+    return currentEL() != 0;
+}
+
 CoreModel*
 CoreModel::construct(uArchOptions_t options,
                      std::function<int(bool)> advance,

--- a/components/uArch/CoreModel/coreModelImpl.hpp
+++ b/components/uArch/CoreModel/coreModelImpl.hpp
@@ -683,6 +683,7 @@ class CoreImpl : public CoreModel
     void setSPSR_el(uint8_t anEL, uint64_t aVal);
     uint64_t getSPSR_el(uint8_t anEL);
     void setDAIF(uint32_t aDAIF);
+    bool isPrivileged();
 
     /* Msutherl: API to read system register value using QEMU encoding */
     uint64_t readUnhashedSysReg(uint8_t opc0, uint8_t opc1, uint8_t opc2, uint8_t crn, uint8_t crm);

--- a/components/uArch/CoreModel/cycle.cpp
+++ b/components/uArch/CoreModel/cycle.cpp
@@ -580,7 +580,7 @@ CoreImpl::retireMem(boost::intrusive_ptr<Instruction> anInsn)
 
             // TRACE TRACKER : Notify trace tracker of store
             // uint64_t logical_timestamp = theCommitNumber + theSRB.size();
-            theTraceTracker.store(theNode, eCore, iter->thePaddr, anInsn->pc(), false /*unknown*/, anInsn->isPriv(), 0);
+            theTraceTracker.store(theNode, eCore, iter->thePaddr, anInsn->pc(), false /*unknown*/, isPrivileged(), 0);
         }
 
         if (iter->theOperation == kRMW) {
@@ -672,7 +672,7 @@ CoreImpl::retireMem(boost::intrusive_ptr<Instruction> anInsn)
             // TRACE TRACKER : Notify trace tracker of load commit
             // uint64_t logical_timestamp = theCommitNumber + theSRB.size();
             theTraceTracker
-              .access(theNode, eCore, iter->thePaddr, anInsn->pc(), false, false, false, anInsn->isPriv(), 0);
+              .access(theNode, eCore, iter->thePaddr, anInsn->pc(), false, false, false, isPrivileged(), 0);
             theTraceTracker.commit(theNode, eCore, iter->thePaddr, anInsn->pc(), 0);
             /* CMU-ONLY-BLOCK-BEGIN */
             //      if (theTrackParallelAccesses ) {
@@ -722,7 +722,7 @@ CoreImpl::retireMem(boost::intrusive_ptr<Instruction> anInsn)
 
             // TRACE TRACKER : Notify trace tracker of store
             //      uint64_t logical_timestamp = theCommitNumber + theSRB.size();
-            theTraceTracker.store(theNode, eCore, iter->thePaddr, anInsn->pc(), false /*unknown*/, anInsn->isPriv(), 0);
+            theTraceTracker.store(theNode, eCore, iter->thePaddr, anInsn->pc(), false /*unknown*/, isPrivileged(), 0);
 
             requireWritePermission(iter);
         }

--- a/components/uArch/CoreModel/memreply.cpp
+++ b/components/uArch/CoreModel/memreply.cpp
@@ -161,7 +161,7 @@ CoreImpl::invalidate(PhysicalMemoryAddress anAddress)
                 ++theRaces;
                 race_counted = true;
             }
-            bool system = temp->theInstruction->isPriv();
+            bool system = isPrivileged();
 
             // if its a completed load, and it has a higher sequence number than
             // first_incomplete, the load attempts forwarding.  If forwarding fails,

--- a/components/uArch/uArchInterfaces.hpp
+++ b/components/uArch/uArchInterfaces.hpp
@@ -560,8 +560,6 @@ struct Instruction : public Flexus::SharedTypes::AbstractInstruction
 
     virtual VirtualMemoryAddress pc() const                                             = 0;
     virtual VirtualMemoryAddress pcNext() const                                         = 0;
-    virtual bool isPriv() const                                                         = 0;
-    virtual void makePriv()                                                             = 0;
     virtual bool isTrap() const                                                         = 0;
     virtual bool preValidate()                                                          = 0;
     virtual bool advancesSimics() const                                                 = 0;


### PR DESCRIPTION
The privilege flag in the instruction was never set. Creating a statistics file that measures everything to be user instruction. We think it is better to have this privilege flag in coreimpl instead of instruction itself. We moved it to the coreimpl.