### PR TITLE
fix: Instruction cache checkpoint checking

### DIFF
--- a/components/uFetch/SimCache.hpp
+++ b/components/uFetch/SimCache.hpp
@@ -59,13 +59,8 @@ struct SimCache
             if (checkpoint["tags"].at(i).size() == 0) {
                 continue;
             }
-            
+
             for (uint32_t j = checkpoint["tags"].at(i).size()-1; j != 0; j--) {
-                // The reason why we reverse the order is because we want to insert the least recent tags first
-                // bool dirty    = checkpoint["tags"].at(i).at(j)["dirty"];
-                // DBG_Assert(!dirty, (<< "Only non dirty block should have been saved, therefore imported"));
-                // bool writable = checkpoint["tags"].at(i).at(j)["writable"];
-                // DBG_Assert(!writable, (<< "Only non writeable block should have been saved, therefore imported"));
                 uint64_t tag  = checkpoint["tags"].at(i).at(j)["tag"];
 
                 theCache.insert(std::make_pair((tag << tag_shift) | i, 0));

--- a/components/uFetch/SimCache.hpp
+++ b/components/uFetch/SimCache.hpp
@@ -56,12 +56,16 @@ struct SimCache
         DBG_Assert((uint64_t)theCache.sets() == checkpoint["tags"].size());
 
         for (std::size_t i{ 0 }; i < theCache.sets(); i++) {
+            if (checkpoint["tags"].at(i).size() == 0) {
+                continue;
+            }
+            
             for (uint32_t j = checkpoint["tags"].at(i).size()-1; j != 0; j--) {
                 // The reason why we reverse the order is because we want to insert the least recent tags first
-                bool dirty    = checkpoint["tags"].at(i).at(j)["dirty"];
-                DBG_Assert(!dirty, (<< "Only non dirty block should have been saved, therefore imported"));
-                bool writable = checkpoint["tags"].at(i).at(j)["writable"];
-                DBG_Assert(!writable, (<< "Only non writeable block should have been saved, therefore imported"));
+                // bool dirty    = checkpoint["tags"].at(i).at(j)["dirty"];
+                // DBG_Assert(!dirty, (<< "Only non dirty block should have been saved, therefore imported"));
+                // bool writable = checkpoint["tags"].at(i).at(j)["writable"];
+                // DBG_Assert(!writable, (<< "Only non writeable block should have been saved, therefore imported"));
                 uint64_t tag  = checkpoint["tags"].at(i).at(j)["tag"];
 
                 theCache.insert(std::make_pair((tag << tag_shift) | i, 0));


### PR DESCRIPTION
This commit fixes two problems: (1) A tag can be empty, which causes the reverse index to become -1; (2) An instruction cache line may see dirty history, because of JIT compiler.