### PR TITLE
fix: Make checkpoint format consistent

### DIFF
--- a/components/Cache/StdArray.hpp
+++ b/components/Cache/StdArray.hpp
@@ -292,6 +292,11 @@ class SetLRU : public Set<_State, _DefaultState>
             Set<_State, _DefaultState>::theBlocks[i].tag() = MemoryAddress((tag << tag_shift) | (set_idx << set_shift));
             Set<_State, _DefaultState>::theBlocks[i].state() = _State::bool2state(dirty, writable);
         }
+
+        // reset the MRU order. Least recently used cache line is in the beginning.
+        for (int32_t i = 0; i < this->theAssociativity; i++) {
+            theMRUOrder[i] = this->theAssociativity - i - 1;
+        }
     }
 
   protected:

--- a/components/MMU/MMUImpl.cpp
+++ b/components/MMU/MMUImpl.cpp
@@ -99,8 +99,8 @@ class FLEXUS_COMPONENT(MMU)
 
             size_t TLBSize = checkpoint["entries"].size();
             for (size_t i = 0; i < TLBSize; i++) {
-                VirtualMemoryAddress aVaddr  = VirtualMemoryAddress((uint64_t)checkpoint["entries"].at(i)["vpn"]);
-                PhysicalMemoryAddress aPaddr = PhysicalMemoryAddress((uint64_t)checkpoint["entries"].at(i)["ppn"]);
+                VirtualMemoryAddress aVaddr  = VirtualMemoryAddress((uint64_t)checkpoint["entries"].at(i)["vpn"] << 12);
+                PhysicalMemoryAddress aPaddr = PhysicalMemoryAddress((uint64_t)checkpoint["entries"].at(i)["ppn"] << 12);
                 uint64_t index               = (uint64_t)(TLBSize - i - 1);
                 theTLB.insert({ aVaddr, TLBentry(aVaddr, aPaddr, index) });
                 DBG_(Dev, (<< "Inserting TLB line with" << aVaddr << " " << aPaddr << "at index: [" << index << "]"));
@@ -127,8 +127,8 @@ class FLEXUS_COMPONENT(MMU)
             checkpoint["entries"] = json::array();
             size_t i              = 0;
             for (const auto& entry : entries) {
-                checkpoint["entries"][i++] = { { "vpn", (uint64_t)entry.theVaddr },
-                                               { "ppn", (uint64_t)entry.thePaddr } };
+                checkpoint["entries"][i++] = { { "vpn", (uint64_t)entry.theVaddr >> 12 },
+                                               { "ppn", (uint64_t)entry.thePaddr >> 12 } };
             }
 
             return checkpoint;

--- a/components/uFetch/SimCache.hpp
+++ b/components/uFetch/SimCache.hpp
@@ -60,10 +60,10 @@ struct SimCache
                 continue;
             }
 
-            for (uint32_t j = checkpoint["tags"].at(i).size()-1; j != 0; j--) {
+            for (uint32_t j = 0; j < checkpoint["tags"].at(i).size(); j++) {
                 uint64_t tag  = checkpoint["tags"].at(i).at(j)["tag"];
 
-                theCache.insert(std::make_pair((tag << tag_shift) | i, 0));
+                this->insert(((tag << tag_shift) | i) << theCacheBlockShift);
 
                 DBG_(Dev, (<< "Loading tag " << std::hex << ((tag << tag_shift) | i)));
             }


### PR DESCRIPTION
This commit includes two fixes: (1) The LRU and the MRU order of the tag arrays. (2) The MMU checkpoint, which should store the page numbers instead of virtual addresses.