### PR TITLE
fix: Remove the MMU copy from the page walker to avoid inconsistency

### DIFF
--- a/components/MMU/MMUImpl.hpp
+++ b/components/MMU/MMUImpl.hpp
@@ -152,6 +152,8 @@ public:
 
     bool available(interface::TLBReqIn const&, index_t anIndex);
     void push(interface::TLBReqIn const&, index_t anIndex, TranslationPtr& aTranslate);
+
+    friend class PageWalk;
 };
 }
 #endif

--- a/components/MMU/pageWalk.cpp
+++ b/components/MMU/pageWalk.cpp
@@ -156,32 +156,32 @@ PageWalk::setupTTResolver(TranslationTransport& aTranslation, uint64_t TTDescrip
 {
     boost::intrusive_ptr<TranslationState> statefulPointer(aTranslation[TranslationStatefulTag]);
     boost::intrusive_ptr<Translation> basicPointer(aTranslation[TranslationBasicTag]);
-    uint8_t PAWidth = theMMU->getPAWidth(statefulPointer->isBR0);
+    uint8_t PAWidth = mmu->theMMU->getPAWidth(statefulPointer->isBR0);
     // Resolve TTBR base.
     switch (statefulPointer->currentLookupLevel) {
         case 0:
             statefulPointer->TTAddressResolver =
               (statefulPointer->isBR0
-                 ? std::make_shared<L0Resolver>(statefulPointer->isBR0, theMMU->Gran0, TTDescriptor, PAWidth)
-                 : std::make_shared<L0Resolver>(statefulPointer->isBR0, theMMU->Gran1, TTDescriptor, PAWidth));
+                 ? std::make_shared<L0Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran0, TTDescriptor, PAWidth)
+                 : std::make_shared<L0Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran1, TTDescriptor, PAWidth));
             break;
         case 1:
             statefulPointer->TTAddressResolver =
               (statefulPointer->isBR0
-                 ? std::make_shared<L1Resolver>(statefulPointer->isBR0, theMMU->Gran0, TTDescriptor, PAWidth)
-                 : std::make_shared<L1Resolver>(statefulPointer->isBR0, theMMU->Gran1, TTDescriptor, PAWidth));
+                 ? std::make_shared<L1Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran0, TTDescriptor, PAWidth)
+                 : std::make_shared<L1Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran1, TTDescriptor, PAWidth));
             break;
         case 2:
             statefulPointer->TTAddressResolver =
               (statefulPointer->isBR0
-                 ? std::make_shared<L2Resolver>(statefulPointer->isBR0, theMMU->Gran0, TTDescriptor, PAWidth)
-                 : std::make_shared<L2Resolver>(statefulPointer->isBR0, theMMU->Gran1, TTDescriptor, PAWidth));
+                 ? std::make_shared<L2Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran0, TTDescriptor, PAWidth)
+                 : std::make_shared<L2Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran1, TTDescriptor, PAWidth));
             break;
         case 3:
             statefulPointer->TTAddressResolver =
               (statefulPointer->isBR0
-                 ? std::make_shared<L3Resolver>(statefulPointer->isBR0, theMMU->Gran0, TTDescriptor, PAWidth)
-                 : std::make_shared<L3Resolver>(statefulPointer->isBR0, theMMU->Gran1, TTDescriptor, PAWidth));
+                 ? std::make_shared<L3Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran0, TTDescriptor, PAWidth)
+                 : std::make_shared<L3Resolver>(statefulPointer->isBR0, mmu->theMMU->Gran1, TTDescriptor, PAWidth));
             break;
         default:
             DBG_Assert(false,
@@ -241,7 +241,7 @@ PageWalk::InitialTranslationSetup(TranslationTransport& aTranslation)
     // setup stateful API that gets passed along with the tr.
     boost::intrusive_ptr<TranslationState> statefulPointer(aTranslation[TranslationStatefulTag]);
     boost::intrusive_ptr<Translation> basicPointer(aTranslation[TranslationBasicTag]);
-    int br = theMMU->checkBR0RangeForVAddr(basicPointer->theVaddr);
+    int br = mmu->theMMU->checkBR0RangeForVAddr(basicPointer->theVaddr);
     if (br != -1) {
         if (br == 0) {
             statefulPointer->isBR0 = true;
@@ -253,10 +253,10 @@ PageWalk::InitialTranslationSetup(TranslationTransport& aTranslation)
               << ", Dropping Request"));
         return false;
     }
-    uint8_t initialLevel                  = theMMU->getInitialLookupLevel(statefulPointer->isBR0);
+    uint8_t initialLevel                  = mmu->theMMU->getInitialLookupLevel(statefulPointer->isBR0);
     statefulPointer->requiredTableLookups = 4 - initialLevel;
     statefulPointer->currentLookupLevel   = initialLevel;
-    statefulPointer->granuleSize          = theMMU->getGranuleSize(statefulPointer->isBR0);
+    statefulPointer->granuleSize          = mmu->theMMU->getGranuleSize(statefulPointer->isBR0);
     statefulPointer->ELRegime             = currentEL();
 
     uint8_t EL = statefulPointer->ELRegime;
@@ -277,9 +277,9 @@ PageWalk::InitialTranslationSetup(TranslationTransport& aTranslation)
 
     uint64_t initialTTBR;
     if (statefulPointer->isBR0)
-        initialTTBR = theMMU->mmu_regs.TTBR0[EL];
+        initialTTBR = mmu->theMMU->mmu_regs.TTBR0[EL];
     else
-        initialTTBR = theMMU->mmu_regs.TTBR1[EL];
+        initialTTBR = mmu->theMMU->mmu_regs.TTBR1[EL];
     setupTTResolver(aTranslation, initialTTBR);
     return true;
 }
@@ -334,7 +334,9 @@ PageWalk::cycle()
                      (<< "stlb hit " << (VirtualMemoryAddress)(tr->theVaddr & (PAGEMASK)) << ":" << tr->theID
                       << std::hex << ":" << res.second));
                 tr->setHit();
-                tr->thePaddr = (PhysicalMemoryAddress)(res.second | (tr->theVaddr & ~(PAGEMASK)));
+                PhysicalMemoryAddress perfectPaddr(API::qemu_api.translate_va2pa(mmu->flexusIndex(), tr->theVaddr));
+                // tr->thePaddr = (PhysicalMemoryAddress)(res.second | (tr->theVaddr & ~(PAGEMASK)));
+                tr->thePaddr = perfectPaddr;
                 mmu->stlb_accesses++;
             } else {
                 DBG_(VVerb,

--- a/components/MMU/pageWalk.hpp
+++ b/components/MMU/pageWalk.hpp
@@ -16,9 +16,6 @@ class MMUComponent;
 
 class PageWalk
 {
-
-    std::shared_ptr<mmu_t> theMMU;
-
     std::list<TranslationTransport> theTranslationTransports;
 
     std::queue<boost::intrusive_ptr<Translation>> theDoneTranslations;
@@ -36,7 +33,6 @@ class PageWalk
     {
     }
     ~PageWalk() {}
-    void setMMU(std::shared_ptr<mmu_t> aMMU) { theMMU = aMMU; }
     void translate(TranslationTransport& aTransport);
     void preTranslate(TranslationTransport& aTransport);
     void cycle();


### PR DESCRIPTION
This PR includes two fixes:
- It removes the replication of the MMU register states from the page walker, which has been causing problem whenever there is an context switching to another process. 
- It bypasses the translation results coming from the TLB to avoid early crashes due to not implementing of the TLB invalidation. 