### PR TITLE
!refactor: LLC and Directory

### DIFF
--- a/components/CMPCache/AbstractArray.hpp
+++ b/components/CMPCache/AbstractArray.hpp
@@ -17,7 +17,7 @@ namespace nCMPCache {
 
 typedef Flexus::SharedTypes::PhysicalMemoryAddress MemoryAddress;
 
-typedef uint32_t BlockOffset;
+typedef uint64_t BlockOffset;
 
 class InvalidCacheAccessException : public std::exception
 {};
@@ -65,7 +65,7 @@ class AbstractArray
     virtual void invalidateBlock(LookupResult_p lookup) = 0;
 
     // Checkpoint reading/writing functions
-    virtual void load_cache_from_ckpt(std::string const&, int32_t anIndex) = 0;
+    virtual void load_cache_from_ckpt(std::string const&, uint64_t anIndex) = 0;
 
     // Addressing helper functions
     MemoryAddress blockAddress(MemoryAddress const& anAddress) const
@@ -75,12 +75,12 @@ class AbstractArray
 
     BlockOffset blockOffset(MemoryAddress const& anAddress) const { return BlockOffset(anAddress & blockOffsetMask); }
 
-    virtual uint32_t freeEvictionResources() const { return UINT_MAX; }
+    virtual uint64_t freeEvictionResources() const { return UINT_MAX; }
     virtual bool evictionResourcePressure() const { return false; }
     virtual bool evictionResourcesAvailable() const { return true; }
     virtual bool evictionResourcesEmpty() const { return true; }
-    virtual void reserveEvictionResource(int32_t n) {}
-    virtual void unreserveEvictionResource(int32_t n) {}
+    virtual void reserveEvictionResource(uint64_t n) {}
+    virtual void unreserveEvictionResource(uint64_t n) {}
     virtual std::pair<_State, MemoryAddress> getPreemptiveEviction() = 0;
 
     virtual bool sameSet(MemoryAddress a, MemoryAddress b) { return false; }
@@ -114,21 +114,15 @@ class AbstractArray
         return nullptr;
     }
 
-    virtual void setLockedThreshold(int32_t threshold)
+    virtual void setLockedThreshold(uint64_t threshold)
     {
         DBG_Assert(theLockedThreshold > 0);
         theLockedThreshold = threshold;
     }
 
-    virtual uint32_t globalCacheSets()
-    {
-        DBG_Assert(false, (<< "Derived class does not implement globalCacheSets() function."));
-        return 0;
-    }
-
   protected:
     MemoryAddress blockOffsetMask;
-    int32_t theLockedThreshold;
+    uint64_t theLockedThreshold;
 
 }; // class AbstractArray
 
@@ -152,7 +146,7 @@ namespace nCMPCache {
  */
 template<typename _State, const _State& _Default>
 AbstractArray<_State>*
-constructArray(std::string& anArrayConfiguration, CMPCacheInfo& theInfo, int32_t theBlockSize)
+constructArray(std::string& anArrayConfiguration, CMPCacheInfo& theInfo, uint64_t theBlockSize)
 {
     std::string& args = anArrayConfiguration;
 

--- a/components/CMPCache/CMPCacheController.cpp
+++ b/components/CMPCache/CMPCacheController.cpp
@@ -73,16 +73,15 @@ CMPCacheController::loadState(std::string const& ckpt_dirname)
 {
 
     std::string real_name = theName;
-    real_name.replace(0, theName.find('-'), "sys");
     // -- LOAD DIRECTORY
     std::string ckpt_filename_cachedir(ckpt_dirname);
-    ckpt_filename_cachedir += "/" + real_name + "-dir.json";
+    ckpt_filename_cachedir += "/" + theName + "-dir-slice.json";
     DBG_(Dev, (<< " Start loading Directory state from " << ckpt_filename_cachedir));
     thePolicy->load_dir_from_ckpt(ckpt_filename_cachedir);
 
     // -- LOAD CACHE
     std::string ckpt_filename_cache(ckpt_dirname);
-    ckpt_filename_cache += "/" + real_name + "-cache.json";
+    ckpt_filename_cache += "/" + theName + "-cache-slice.json";
     DBG_(Dev, (<< " Start loading Cache state from " << ckpt_filename_cache));
     thePolicy->load_cache_from_ckpt(ckpt_filename_cache);
 }

--- a/components/CMPCache/InfiniteDirectory.hpp
+++ b/components/CMPCache/InfiniteDirectory.hpp
@@ -149,6 +149,11 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
     }
     virtual boost::intrusive_ptr<AbstractLookupResult<_State>> lookup(MemoryAddress address)
     {
+        // Make sure this address is in the right range.
+        uint64_t node_index = (address >> theBlockShift) % theNumNodes;
+
+        DBG_Assert(node_index == theNodeId, (<< "Address " << std::hex << address << " is not in the correct node. Expected node " << theNodeId << " but got node " << node_index));
+
         iterator iter = theDirectory.find(address);
         return LookupResult_p(new LookupResult(iter, (iter != theDirectory.end())));
     }

--- a/components/CMPCache/InfiniteDirectory.hpp
+++ b/components/CMPCache/InfiniteDirectory.hpp
@@ -192,6 +192,11 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
 
         for (uint32_t i{ 0 }; i < cache_size; i++) {
             uint64_t address = checkpoint.at(i)["tag"];
+
+            uint64_t node_idx_of_cacheline = (address >> theBlockShift) % theNumNodes;
+
+            DBG_Assert(node_idx_of_cacheline == theNodeId, (<< "Address " << std::hex << address << " is not in the correct node. Expected node " << theNodeId << " but got node " << node_idx_of_cacheline));
+
             std::bitset<MAX_NUM_SHARERS> sharers(checkpoint.at(i)["sharers"].get<std::string>());
 
             DBG_Assert(sharers.size() <= MAX_NUM_SHARERS, (<< "Sharers size mismatch"));
@@ -199,10 +204,7 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
             // It's stupid but that's the only way to workaround this object
             SimpleDirectoryState state(theNumSharers);
             state = sharers;
-
-            if (((address >> theBlockShift) % theNumNodes) == theNodeId) {
-                theDirectory.insert(InfDirEntry(PhysicalMemoryAddress(address), state));
-            }
+            theDirectory.insert(InfDirEntry(PhysicalMemoryAddress(address), state));
         }
 
         DBG_(Trace, (<< "Directory loaded"));

--- a/components/CMPCache/InfiniteDirectory.hpp
+++ b/components/CMPCache/InfiniteDirectory.hpp
@@ -106,41 +106,15 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
     DirEvictBuffer<_EState> theEvictBuffer;
 
     int32_t theNumSharers;
-    int32_t theBlockSize;
-    int32_t theBanks;
-    int32_t theGlobalBankIndex;
-    int32_t theLocalBankIndex;
-    int32_t theBankInterleaving;
-    int32_t theGroups;
-    int32_t theGroupIndex;
-    int32_t theGroupInterleaving;
+    uint32_t theBlockSize;
+    uint32_t theBlockShift;
 
-    int32_t theBankShift;
-    int32_t theBankMask;
-    int32_t theGroupShift;
-    int32_t theGroupMask;
-    int32_t theSkewShift;
+    uint64_t theNodeId;
+    uint64_t theNumNodes;
 
     bool theSameSetReturnValue;
 
     std::string theName;
-
-    int32_t getBank(uint64_t addr)
-    {
-        if (theSkewShift >= 0) {
-            return ((addr >> theBankShift) ^ (addr >> theSkewShift)) & theBankMask;
-        } else {
-            return (addr >> theBankShift) & theBankMask;
-        }
-    }
-    int32_t getGroup(uint64_t addr)
-    {
-        if (theSkewShift >= 0) {
-            return ((addr >> theGroupShift) ^ (addr >> theSkewShift)) & theGroupMask;
-        } else {
-            return (addr >> theGroupShift) & theGroupMask;
-        }
-    }
 
   public:
     typedef InfiniteLookupResult LookupResult;
@@ -153,31 +127,14 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
     {
         theNumSharers        = theInfo.theCores;
         theBlockSize         = theInfo.theBlockSize;
-        theBanks             = theInfo.theNumBanks;
-        theBankInterleaving  = theInfo.theBankInterleaving;
-        theGlobalBankIndex   = theInfo.theNodeId;
-        theGroups            = theInfo.theNumGroups;
-        theGroupInterleaving = theInfo.theGroupInterleaving;
 
-        theLocalBankIndex = theGlobalBankIndex % theBanks;
-        theGroupIndex     = theGlobalBankIndex / theBanks;
+        // The current interleaving scheme requires a block size of 64 bytes
+        DBG_Assert(theBlockSize == 64);
 
-        theBankShift = log_base2(theBankInterleaving);
-        theBankMask  = theBanks - 1;
-
-        theGroupShift = log_base2(theGroupInterleaving);
-        theGroupMask  = theGroups - 1;
-
-        theSkewShift = -1;
-
-        std::list<std::pair<std::string, std::string>>::const_iterator iter = args.begin();
-        for (; iter != args.end(); iter++) {
-            if (strcasecmp(iter->first.c_str(), "skew_shift") == 0) {
-                theSkewShift = boost::lexical_cast<int>(iter->second);
-            } else {
-                DBG_Assert(false, (<< "Unrecognized parameter '" << iter->first << "' passed to InfiniteDirectory."));
-            }
-        }
+        theBlockShift = log_base2(theBlockSize);
+        theNodeId  = theInfo.theNodeId;
+        theNumNodes = Flexus::Core::ComponentManager::getComponentManager().systemWidth();;
+        
     }
 
     virtual bool allocate(boost::intrusive_ptr<AbstractLookupResult<_State>> lookup,
@@ -238,8 +195,9 @@ class InfiniteDirectory : public AbstractDirectory<_State, _EState>
             SimpleDirectoryState state(theNumSharers);
             state = sharers;
 
-            if ((getBank(address) == theLocalBankIndex) && (getGroup(address) == theGroupIndex))
+            if (((address >> theBlockShift) % theNumNodes) == theNodeId) {
                 theDirectory.insert(InfDirEntry(PhysicalMemoryAddress(address), state));
+            }
         }
 
         DBG_(Trace, (<< "Directory loaded"));

--- a/components/CMPCache/SimpleDirectoryState.hpp
+++ b/components/CMPCache/SimpleDirectoryState.hpp
@@ -108,6 +108,12 @@ class SimpleDirectoryState
         for (int32_t i = 0; i < theNumSharers; i++) {
             theSharers[i] = s[i];
         }
+
+        // Other fields in s should be zero. 
+        for (int32_t i = theNumSharers; i < MAX_NUM_SHARERS; i++) {
+            DBG_Assert(s[i] == false, (<< "Extra bits set in bitset"));
+        }
+
         return *this;
     }
 

--- a/components/CMPCache/SimpleDirectoryState.hpp
+++ b/components/CMPCache/SimpleDirectoryState.hpp
@@ -3,7 +3,7 @@
 #define __SIMPLE_DIRECTORY_STATE_HPP__
 #include <bitset>
 #include <boost/dynamic_bitset.hpp>
-#define MAX_NUM_SHARERS 128
+#define MAX_NUM_SHARERS 256
 
 namespace nCMPCache {
 
@@ -95,14 +95,6 @@ class SimpleDirectoryState
         theNumSharers = numSharers;
     }
 
-    SimpleDirectoryState& operator=(uint64_t s)
-    {
-        for (int32_t i = 0; i < theNumSharers; i++, s >>= 1) {
-            theSharers[i] = (((s & 1) == 1) ? true : false);
-        }
-        return *this;
-    }
-
     SimpleDirectoryState& operator=(std::bitset<MAX_NUM_SHARERS> s)
     {
         for (int32_t i = 0; i < theNumSharers; i++) {
@@ -121,14 +113,6 @@ class SimpleDirectoryState
     {
         for (int32_t i = 0; i < theNumSharers; i++) {
             theSharers[i] |= s[i];
-        }
-        return *this;
-    }
-
-    SimpleDirectoryState& operator|=(uint64_t s)
-    {
-        for (int32_t i = 0; i < theNumSharers; i++, s >>= 1) {
-            theSharers[i] = theSharers[i] || (((s & 1) == 1) ? true : false);
         }
         return *this;
     }

--- a/components/CMPCache/StdArray.hpp
+++ b/components/CMPCache/StdArray.hpp
@@ -366,7 +366,6 @@ class SetLRU : public Set<_State, _DefaultState>
         theMRUOrder[index]                                   = mru_order_index;
         this->theBlocks[index].tag()   = MemoryAddress(tag);
         this->theBlocks[index].state() = state;
-        DBG_(Trace, NoDefaultOps()(<< index << "-LLC: Loading block " << std::hex << tag << " in state " << state));
     }
 
   protected:

--- a/components/CMPCache/StdArray.hpp
+++ b/components/CMPCache/StdArray.hpp
@@ -22,8 +22,8 @@ namespace nCMPCache {
 
 typedef Flexus::SharedTypes::PhysicalMemoryAddress MemoryAddress;
 
-typedef int32_t SetIndex;
-typedef uint32_t BlockOffset;
+typedef uint32_t SetIndex;
+typedef uint64_t BlockOffset;
 
 enum ReplacementPolicy
 {
@@ -120,7 +120,7 @@ template<typename _State, const _State& _DefaultState>
 class Set
 {
   public:
-    Set(const int32_t aAssociativity)
+    Set(const uint64_t aAssociativity)
     {
         theAssociativity = aAssociativity;
         theBlocks        = new Block<_State, _DefaultState>[theAssociativity];
@@ -133,7 +133,7 @@ class Set
 
     LookupResult_p lookupBlock(const MemoryAddress anAddress)
     {
-        int32_t i, t = -1;
+        uint64_t i, t = 0xffffffffffffffffULL;
 
         // Linearly search through the set for the matching block
         // This could be made faster for higher-associativity sets
@@ -146,7 +146,7 @@ class Set
                 t = i;
             }
         }
-        if (t >= 0) { return LookupResult_p(new LookupResult(this, &(theBlocks[t]), anAddress, false)); }
+        if (t != 0xffffffffffffffffULL) { return LookupResult_p(new LookupResult(this, &(theBlocks[t]), anAddress, false)); }
 
         // Miss on this set
         return LookupResult_p(new LookupResult(this, nullptr, anAddress, false));
@@ -168,7 +168,7 @@ class Set
             Block<_State, _DefaultState>* victim = pickVictim();
 
             // Create lookup result now and remember the block state
-            LookupResult_p v_lookup(new LookupResult(this, victim, blockAddress(victim), true));
+            LookupResult_p v_lookup(new LookupResult(this, victim, this->blockAddress(victim), true));
             v_lookup->isHit = false;
 
             victim->tag() = anAddress;
@@ -205,10 +205,10 @@ class Set
 
             Block<_State, _DefaultState>* victim = pickLockedVictim();
 
-            DBG_(Trace, (<< "Replacing block " << std::hex << blockAddress(victim) << " in state " << victim->state()));
+            DBG_(Trace, (<< "Replacing block " << std::hex << this->blockAddress(victim) << " in state " << victim->state()));
 
             // Create lookup result now and remember the block state
-            LookupResult_p v_lookup(new LookupResult(this, victim, blockAddress(victim), true));
+            LookupResult_p v_lookup(new LookupResult(this, victim, this->blockAddress(victim), true));
             v_lookup->isHit = false;
 
             if (swap_locked_victim) { lookup->theBlock->tag() = victim->tag(); }
@@ -230,13 +230,16 @@ class Set
     virtual bool recordAccess(Block<_State, _DefaultState>* aBlock)    = 0;
     virtual void invalidateBlock(Block<_State, _DefaultState>* aBlock) = 0;
 
-    virtual void load_set_from_ckpt(uint32_t index, uint32_t mru_index, uint64_t tag, bool dirty, bool writable) = 0;
+    virtual void load_set_from_ckpt(uint64_t index, uint64_t mru_index, uint64_t tag, bool dirty, bool writable) = 0;
 
-    MemoryAddress blockAddress(const Block<_State, _DefaultState>* theBlock) { return theBlock->tag(); }
+    MemoryAddress blockAddress(const Block<_State, _DefaultState>* theBlock)
+    { 
+        return theBlock->tag(); 
+    }
 
-    int32_t count(const MemoryAddress& aTag)
+    uint64_t count(const MemoryAddress& aTag)
     {
-        int32_t i, res = 0;
+        uint64_t i, res = 0;
 
         for (i = 0; i < theAssociativity; i++) {
             if (theBlocks[i].tag() == aTag) { res++; }
@@ -248,7 +251,7 @@ class Set
     std::list<MemoryAddress> getTags()
     {
         std::list<MemoryAddress> tag_list;
-        for (int32_t i = 0; i < theAssociativity; i++) {
+        for (uint64_t i = 0; i < theAssociativity; i++) {
             if (theBlocks[i].state().isValid()) { tag_list.push_back(theBlocks[i].tag()); }
         }
         return tag_list;
@@ -259,7 +262,7 @@ class Set
         int locked_count    = 0;
         int unlocked_count  = 0;
         int unlocked_thresh = theAssociativity - max_locked;
-        for (int32_t i = 0; i < theAssociativity; i++) {
+        for (uint64_t i = 0; i < theAssociativity; i++) {
             if (theBlocks[i].state().isLocked()) {
                 locked_count++;
                 if (locked_count >= max_locked) { return true; }
@@ -274,7 +277,7 @@ class Set
     virtual bool lockedVictimAvailable() const
     {
         // Look for a block that is Locked, but not protected
-        for (int32_t i = 0; i < theAssociativity; i++) {
+        for (uint64_t i = 0; i < theAssociativity; i++) {
             if (theBlocks[i].state().isLocked() && !theBlocks[i].state().isProtected()) { return true; }
         }
         return false;
@@ -282,7 +285,7 @@ class Set
 
   protected:
     Block<_State, _DefaultState>* theBlocks;
-    int32_t theAssociativity;
+    SetIndex theAssociativity;
 
 }; // class Set
 
@@ -290,24 +293,24 @@ template<typename _State, const _State& _DefaultState>
 class SetLRU : public Set<_State, _DefaultState>
 {
   public:
-    SetLRU(const int32_t aAssociativity)
+    SetLRU(const uint64_t aAssociativity)
       : Set<_State, _DefaultState>(aAssociativity)
     {
-        theMRUOrder = new int[aAssociativity];
+        theMRUOrder = new SetIndex[aAssociativity];
 
-        for (int32_t i = 0; i < aAssociativity; i++) {
+        for (uint64_t i = 0; i < aAssociativity; i++) {
             theMRUOrder[i] = i;
         }
     }
 
     virtual Block<_State, _DefaultState>* pickVictim()
     {
-        for (int32_t i = Set<_State, _DefaultState>::theAssociativity - 1; i >= 0; i--) {
-            int32_t index = theMRUOrder[i];
+        for (SetIndex i = this->theAssociativity - 1; i >= 0; i--) {
+            SetIndex index = theMRUOrder[i];
             // Can't be protected or locked
-            if (!Set<_State, _DefaultState>::theBlocks[index].state().isProtected() &&
-                !Set<_State, _DefaultState>::theBlocks[index].state().isLocked()) {
-                return &(Set<_State, _DefaultState>::theBlocks[index]);
+            if (!this->theBlocks[index].state().isProtected() &&
+                !this->theBlocks[index].state().isLocked()) {
+                return &(this->theBlocks[index]);
             }
         }
         DBG_Assert(false, (<< "All blocks in the set are protected."));
@@ -316,12 +319,12 @@ class SetLRU : public Set<_State, _DefaultState>
 
     virtual Block<_State, _DefaultState>* pickLockedVictim()
     {
-        for (int32_t i = Set<_State, _DefaultState>::theAssociativity - 1; i >= 0; i--) {
-            int32_t index = theMRUOrder[i];
+        for (SetIndex i = this->theAssociativity - 1; i >= 0; i--) {
+            SetIndex index = theMRUOrder[i];
             // Can't be protected or locked
-            if (!Set<_State, _DefaultState>::theBlocks[index].state().isProtected() &&
-                Set<_State, _DefaultState>::theBlocks[index].state().isLocked()) {
-                return &(Set<_State, _DefaultState>::theBlocks[index]);
+            if (!this->theBlocks[index].state().isProtected() &&
+                this->theBlocks[index].state().isLocked()) {
+                return &(this->theBlocks[index]);
             }
         }
         DBG_Assert(false, (<< "All blocks in the set are protected."));
@@ -330,10 +333,10 @@ class SetLRU : public Set<_State, _DefaultState>
 
     virtual bool victimAvailable()
     {
-        for (int32_t i = Set<_State, _DefaultState>::theAssociativity - 1; i >= 0; i--) {
-            int32_t index = theMRUOrder[i];
-            if (!Set<_State, _DefaultState>::theBlocks[index].state().isProtected() &&
-                !Set<_State, _DefaultState>::theBlocks[index].state().isLocked()) {
+        for (SetIndex i = this->theAssociativity - 1; i >= 0; i--) {
+            SetIndex index = theMRUOrder[i];
+            if (!this->theBlocks[index].state().isProtected() &&
+                !this->theBlocks[index].state().isLocked()) {
                 return true;
             }
         }
@@ -342,7 +345,7 @@ class SetLRU : public Set<_State, _DefaultState>
 
     virtual bool recordAccess(Block<_State, _DefaultState>* aBlock)
     {
-        int32_t theBlockNum = aBlock - Set<_State, _DefaultState>::theBlocks;
+        SetIndex theBlockNum = aBlock - this->theBlocks;
         // If it's already at the head, just return now
         if (theMRUOrder[0] == theBlockNum) { return false; }
         moveToHead(theBlockNum);
@@ -351,26 +354,28 @@ class SetLRU : public Set<_State, _DefaultState>
 
     virtual void invalidateBlock(Block<_State, _DefaultState>* aBlock)
     {
-        int32_t theBlockNum = aBlock - Set<_State, _DefaultState>::theBlocks;
+        SetIndex theBlockNum = aBlock - this->theBlocks;
         moveToTail(theBlockNum);
     }
 
-    virtual void load_set_from_ckpt(uint32_t index, uint32_t mru_order_index, uint64_t tag, bool dirty, bool writable)
+    virtual void load_set_from_ckpt(uint64_t index, uint64_t mru_order_index, uint64_t tag, bool dirty, bool writable)
     {
+        
+        DBG_Assert(index < uint64_t(this->theAssociativity));
         _State state(_State::bool2state(dirty, writable));
         theMRUOrder[index]                                   = mru_order_index;
-        Set<_State, _DefaultState>::theBlocks[index].tag()   = MemoryAddress(tag);
-        Set<_State, _DefaultState>::theBlocks[index].state() = state;
+        this->theBlocks[index].tag()   = MemoryAddress(tag);
+        this->theBlocks[index].state() = state;
         DBG_(Trace, NoDefaultOps()(<< index << "-LLC: Loading block " << std::hex << tag << " in state " << state));
     }
 
   protected:
-    inline int32_t lruListHead(void) { return theMRUOrder[0]; }
-    inline int32_t lruListTail(void) { return theMRUOrder[Set<_State, _DefaultState>::theAssociativity - 1]; }
+    inline SetIndex lruListHead(void) { return theMRUOrder[0]; }
+    inline SetIndex lruListTail(void) { return theMRUOrder[this->theAssociativity - 1]; }
 
     inline void moveToHead(const SetIndex aBlock)
     {
-        int32_t i = 0;
+        SetIndex i = 0;
         while (theMRUOrder[i] != aBlock)
             i++;
         while (i > 0) {
@@ -382,14 +387,14 @@ class SetLRU : public Set<_State, _DefaultState>
 
     inline void moveToTail(const SetIndex aBlock)
     {
-        int32_t i = 0;
+        SetIndex i = 0;
         while (theMRUOrder[i] != aBlock)
             i++;
-        while (i < (Set<_State, _DefaultState>::theAssociativity - 1)) {
+        while (i < (this->theAssociativity - 1)) {
             theMRUOrder[i] = theMRUOrder[i + 1];
             i++;
         }
-        theMRUOrder[Set<_State, _DefaultState>::theAssociativity - 1] = aBlock;
+        theMRUOrder[this->theAssociativity - 1] = aBlock;
     }
 
     SetIndex* theMRUOrder;
@@ -403,62 +408,44 @@ class StdArray : public AbstractArray<_State>
     CMPCacheInfo theInfo;
 
     // Masks to address portions of the cache
-    int32_t theAssociativity;
-    int32_t theReplacementPolicy;
-    int32_t theBlockSize;
-    int32_t theBanks;
-    int32_t theTotalBanks;
-    int32_t theGlobalBankIndex;
-    int32_t theLocalBankIndex;
-    int32_t theBankInterleaving;
-    int32_t theGroups;
-    int32_t theGroupIndex;
-    int32_t theGroupInterleaving;
+    uint64_t theAssociativity;
+    uint64_t theReplacementPolicy;
+    uint64_t theBlockSize;
 
-    int32_t theNumSets;
-    MemoryAddress tagMask;
-    int32_t setHighShift;
-    int32_t setMidShift;
-    int32_t setLowShift;
-    uint64_t setLowMask;
-    uint64_t setMidMask;
-    uint64_t setHighMask;
+    uint64_t theNumSets;
+    uint64_t theSetIndexShift;
+    uint64_t theSetIndexMask;
 
-    int32_t theBankMask, theBankShift;
-    int32_t theGroupMask, theGroupShift;
+    uint64_t theNumNodes;
+
+    MemoryAddress theTagMask;
 
     Set<_State, _DefaultState>** theSets;
 
   public:
     virtual ~StdArray() {}
     StdArray(CMPCacheInfo& aCacheInfo,
-             const int32_t aBlockSize,
+             const uint64_t aBlockSize,
              const std::list<std::pair<std::string, std::string>>& theConfiguration)
       : theInfo(aCacheInfo)
     {
         theBlockSize         = aBlockSize;
-        theBanks             = theInfo.theNumBanks;
-        theBankInterleaving  = theInfo.theBankInterleaving;
-        theGroups            = theInfo.theNumGroups;
-        theGroupInterleaving = theInfo.theGroupInterleaving;
-        DBG_(Dev, (<< "theGroupInterleaving = " << theGroupInterleaving));
 
-        theGlobalBankIndex = theInfo.theNodeId;
-        theLocalBankIndex  = theInfo.theNodeId % theBanks;
-        theGroupIndex      = theInfo.theNodeId / theBanks;
+        // Currently, we only test with 64-byte blocks
+        // A larger block can cause wrong interleaving in the LLC.
+        DBG_Assert(theBlockSize == 64);
 
-        theTotalBanks = theBanks * theGroups;
+        theNumNodes = Flexus::Core::ComponentManager::getComponentManager().systemWidth();
+        DBG_Assert(theNumNodes > 0);
 
         std::list<std::pair<std::string, std::string>>::const_iterator iter = theConfiguration.begin();
         for (; iter != theConfiguration.end(); iter++) {
             if (iter->first == "sets") {
                 theNumSets = strtoll(iter->second.c_str(), nullptr, 0);
-            } else if (iter->first == "total_sets" || iter->first == "global_sets") {
-                int32_t global_sets = strtol(iter->second.c_str(), nullptr, 0);
-                theNumSets          = global_sets / theTotalBanks;
-                DBG_Assert((theNumSets * theTotalBanks) == global_sets,
-                           (<< "global_sets (" << global_sets << ") is not divisible by number of banks ("
-                            << theTotalBanks << ")"));
+            } else if (iter->first == "total_sets") {
+                uint64_t total_sets = strtoll(iter->second.c_str(), nullptr, 0);
+                DBG_Assert(total_sets % theNumNodes == 0);
+                theNumSets = total_sets / theNumNodes;
             } else if (strcasecmp(iter->first.c_str(), "assoc") == 0 ||
                        strcasecmp(iter->first.c_str(), "associativity") == 0) {
                 theAssociativity = strtol(iter->second.c_str(), nullptr, 0);
@@ -501,79 +488,44 @@ class StdArray : public AbstractArray<_State>
         // Set indexes and masks
         DBG_Assert((theNumSets & (theNumSets - 1)) == 0);
         DBG_Assert(((theBlockSize - 1) & theBlockSize) == 0);
-        DBG_Assert(((theBankInterleaving - 1) & theBankInterleaving) == 0);
-        DBG_Assert(((theGroupInterleaving - 1) & theGroupInterleaving) == 0);
 
-        DBG_Assert((theBankInterleaving * theBanks) <= theGroupInterleaving,
-                   (<< "Invalid interleaving: BI = " << theBankInterleaving << ", Banks = " << theBanks
-                    << ", GI = " << theGroupInterleaving << ", Groups = " << theGroups));
+        uint64_t blockOffsetBits      = log_base2(theBlockSize);
+        // int32_t indexBits            = log_base2(theNumSets);
+        this->theSetIndexShift       = blockOffsetBits;
+        this->theSetIndexMask        = (theNumSets - 1); // mask is applied after shift.
 
-        int32_t blockOffsetBits      = log_base2(theBlockSize);
-        int32_t indexBits            = log_base2(theNumSets);
-        int32_t bankBits             = log_base2(theBanks);
-        int32_t bankInterleavingBits = log_base2(theBankInterleaving);
-
-        int32_t groupBits             = log_base2(theGroups);
-        int32_t groupInterleavingBits = log_base2(theGroupInterleaving);
-
-        int32_t lowBits  = bankInterleavingBits - blockOffsetBits;
-        int32_t midBits  = groupInterleavingBits - bankInterleavingBits - bankBits;
-        int32_t highBits = indexBits - midBits - lowBits;
-        if ((midBits + lowBits) > indexBits) {
-            midBits  = indexBits - lowBits;
-            highBits = 0;
-        }
-
-        setLowMask  = (1 << lowBits) - 1;
-        setMidMask  = ((1 << midBits) - 1) << lowBits;
-        setHighMask = ((1 << highBits) - 1) << (midBits + lowBits);
-
-        setLowShift  = blockOffsetBits;
-        setMidShift  = bankBits + blockOffsetBits;
-        setHighShift = groupBits + bankBits + blockOffsetBits;
-
-        theBankMask   = theBanks - 1;
-        theBankShift  = bankInterleavingBits;
-        theGroupMask  = theGroups - 1;
-        theGroupShift = groupInterleavingBits;
-
-        DBG_(Dev,
-             (<< "blockOffsetBits = " << std::dec << blockOffsetBits << ", indexBits = " << std::dec << indexBits
-              << ", bankBits = " << std::dec << bankBits << ", bankInterleavingBits = " << std::dec
-              << bankInterleavingBits << ", groupBits = " << std::dec << groupBits
-              << ", groupInterleavingBits = " << std::dec << groupInterleavingBits << ", lowBits = " << std::dec
-              << lowBits << ", midBits = " << std::dec << midBits << ", highBits = " << std::dec << highBits
-              << ", setLowMask = " << std::hex << setLowMask << ", setMidMask = " << std::hex << setMidMask
-              << ", setHighMask = " << std::hex << setHighMask << ", setLowShift = " << std::dec << setLowShift
-              << ", setMidShift = " << std::dec << setMidShift << ", setHighShift = " << std::dec << setHighShift
-              << ", theBankMask = " << std::hex << theBankMask << ", theBankShift = " << std::dec << theBankShift
-              << ", theGroupMask = " << std::hex << theGroupMask << ", theGroupShift = " << std::dec << theGroupShift));
-
-        tagMask = MemoryAddress(~0ULL & ~((uint64_t)(theBlockSize - 1)));
+        this->theTagMask = MemoryAddress(~0ULL & ~((uint64_t)(theBlockSize - 1)));
 
         // Allocate the sets
         theSets = new Set<_State, _DefaultState>*[theNumSets];
         DBG_Assert(theSets);
 
-        for (int32_t i = 0; i < theNumSets; i++) {
+        for (uint64_t i = 0; i < theNumSets; i++) {
 
             switch (theReplacementPolicy) {
-                case REPLACEMENT_LRU: theSets[i] = new SetLRU<_State, _DefaultState>(theAssociativity); break;
+                case REPLACEMENT_LRU: theSets[i] = new SetLRU<_State, _DefaultState>(theAssociativity); 
+                break;
                 default: DBG_Assert(false);
             };
         }
+
+        DBG_(Crit, (<< "Created CMP Cache StdArray with " << theNumSets << " sets, " << theAssociativity << " ways"));
     }
 
     // Main array lookup function
     virtual boost::intrusive_ptr<AbstractArrayLookupResult<_State>> operator[](const MemoryAddress& anAddress)
     {
+        uint64_t set_number = this->makeSet(anAddress);
+
         DBG_(Trace,
-             (<< "Looking for block " << std::hex << anAddress << " in set " << makeSet(anAddress)
+             (<< "Looking for block " << std::hex << anAddress << " in set " << set_number
               << " theNumSets = " << theNumSets));
+
+        DBG_Assert(set_number < theNumSets && set_number >= 0);
         boost::intrusive_ptr<AbstractArrayLookupResult<_State>> ret =
-          theSets[makeSet(anAddress)]->lookupBlock(blockAddress(anAddress));
+          theSets[set_number]->lookupBlock(this->blockAddress(anAddress));
         DBG_(Trace,
-             (<< "Found block " << std::hex << anAddress << " in set " << makeSet(anAddress) << " in state "
+             (<< "Found block " << std::hex << anAddress << " in set " << this->makeSet(anAddress) << " in state "
               << ret->state()));
         return ret;
     }
@@ -586,7 +538,7 @@ class StdArray : public AbstractArray<_State>
           dynamic_cast<StdLookupResult<_State, _DefaultState>*>(lookup.get());
         DBG_Assert(std_lookup != nullptr);
 
-        return std_lookup->theSet->allocate(std_lookup, blockAddress(anAddress));
+        return std_lookup->theSet->allocate(std_lookup, this->blockAddress(anAddress));
     }
 
     virtual bool recordAccess(boost::intrusive_ptr<AbstractArrayLookupResult<_State>> lookup)
@@ -616,7 +568,7 @@ class StdArray : public AbstractArray<_State>
 
     // Checkpoint reading/writing functions
 
-    virtual void load_cache_from_ckpt(std::string const& filename, int32_t theIndex)
+    virtual void load_cache_from_ckpt(std::string const& filename, uint64_t theIndex)
     {
 
         std::ifstream ifs(filename.c_str(), std::ios::in);
@@ -630,11 +582,16 @@ class StdArray : public AbstractArray<_State>
         ifs >> checkpoint;
 
         DBG_Assert((uint64_t)theAssociativity == checkpoint["associativity"]);
-        DBG_Assert((uint64_t)theNumSets == checkpoint["tags"].size());
+        DBG_Assert((uint64_t)theNumSets == (checkpoint["tags"].size() / theNumNodes)); // Only load one slice.
 
-        for (int32_t i{ 0 }; i < theNumSets; i++) {
-            // if ((getBank(addr) == theLocalBankIndex) && (getGroup(addr) == theGroupIndex))
-            for (uint16_t j = 0; j < checkpoint["tags"].at(i).size(); j++) {
+        for (uint64_t i = 0; i < theNumSets; i++) {
+            // Only load the set that corresponds to this slice.
+            if (i % theNumNodes != theIndex) {
+                continue;
+            }
+
+            assert(checkpoint["tags"].at(i).size() <= (uint64_t)theAssociativity);
+            for (uint64_t j = 0; j < checkpoint["tags"].at(i).size(); j++) {
                 uint64_t tag  = checkpoint["tags"].at(i).at(j)["tag"];
                 bool dirty    = checkpoint["tags"].at(i).at(j)["dirty"];
                 bool writable = checkpoint["tags"].at(i).at(j)["writable"];
@@ -647,37 +604,35 @@ class StdArray : public AbstractArray<_State>
     }
 
     // Addressing helper functions
-    MemoryAddress blockAddress(MemoryAddress const& anAddress) const { return MemoryAddress(anAddress & tagMask); }
+    MemoryAddress blockAddress(MemoryAddress const& anAddress) const 
+    { 
+        return MemoryAddress(anAddress & this->theTagMask); 
+    }
 
     SetIndex makeSet(const MemoryAddress& anAddress) const
     {
-        return ((anAddress >> setLowShift) & setLowMask) | ((anAddress >> setMidShift) & setMidMask) |
-               ((anAddress >> setHighShift) & setHighMask);
+        return ((anAddress >> this->theSetIndexShift) & this->theSetIndexMask);
     }
 
-    int32_t getBank(const MemoryAddress& anAddress) const { return ((anAddress >> theBankShift) & theBankMask); }
+    virtual bool sameSet(MemoryAddress a, MemoryAddress b) { return (this->makeSet(a) == this->makeSet(b)); }
 
-    int32_t getGroup(const MemoryAddress& anAddress) const { return ((anAddress >> theGroupShift) & theGroupMask); }
-
-    virtual bool sameSet(MemoryAddress a, MemoryAddress b) { return (makeSet(a) == makeSet(b)); }
-
-    virtual std::list<MemoryAddress> getSetTags(MemoryAddress addr) { return theSets[makeSet(addr)]->getTags(); }
+    virtual std::list<MemoryAddress> getSetTags(MemoryAddress addr) { return theSets[this->makeSet(addr)]->getTags(); }
     virtual bool setAlmostFull(boost::intrusive_ptr<AbstractArrayLookupResult<_State>> lookup,
                                MemoryAddress const& anAddress) const
     {
-        return theSets[makeSet(anAddress)]->almostFull(AbstractArray<_State>::theLockedThreshold);
+        return theSets[this->makeSet(anAddress)]->almostFull(AbstractArray<_State>::theLockedThreshold);
     }
 
     virtual bool lockedVictimAvailable(boost::intrusive_ptr<AbstractArrayLookupResult<_State>> lookup,
                                        MemoryAddress const& anAddress) const
     {
-        return theSets[makeSet(anAddress)]->lockedVictimAvailable();
+        return theSets[this->makeSet(anAddress)]->lockedVictimAvailable();
     }
 
     virtual bool victimAvailable(boost::intrusive_ptr<AbstractArrayLookupResult<_State>> lookup,
                                  MemoryAddress const& anAddress) const
     {
-        return theSets[makeSet(anAddress)]->victimAvailable();
+        return theSets[this->makeSet(anAddress)]->victimAvailable();
     }
 
     virtual boost::intrusive_ptr<AbstractArrayLookupResult<_State>> replaceLockedBlock(
@@ -689,17 +644,14 @@ class StdArray : public AbstractArray<_State>
           dynamic_cast<StdLookupResult<_State, _DefaultState>*>(lookup.get());
         DBG_Assert(std_lookup != nullptr);
 
-        return std_lookup->theSet->replaceLocked(std_lookup, blockAddress(anAddress));
+        return std_lookup->theSet->replaceLocked(std_lookup, this->blockAddress(anAddress));
     }
 
-    virtual void setLockedThreshold(int32_t threshold)
+    virtual void setLockedThreshold(uint64_t threshold)
     {
         DBG_Assert(threshold > 0 && threshold < theAssociativity);
         AbstractArray<_State>::theLockedThreshold = threshold;
     }
-
-    virtual uint32_t globalCacheSets() { return theNumSets * theTotalBanks; }
-
 }; // class StdArray
 
 }; // namespace nCMPCache

--- a/components/Cache/CacheImpl.cpp
+++ b/components/Cache/CacheImpl.cpp
@@ -73,6 +73,7 @@ class FLEXUS_COMPONENT(Cache)
     {
         theBusTxCountdown = 0;
         theBusDirection   = kIdle;
+        DBG_Assert(cfg.Cores == 1);
 
         auto cores = cfg.Cores ?: Flexus::Core::ComponentManager::getComponentManager().systemWidth();
 

--- a/components/CommonQEMU/Serializers.hpp
+++ b/components/CommonQEMU/Serializers.hpp
@@ -9,7 +9,7 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/tracking.hpp>
 
-#define MAX_NUM_SHARERS 128
+#define MAX_NUM_SHARERS 256
 
 namespace boost {
 namespace serialization {

--- a/components/SplitDestinationMapper/SplitDestinationMapperImpl.cpp
+++ b/components/SplitDestinationMapper/SplitDestinationMapperImpl.cpp
@@ -80,6 +80,10 @@ class FLEXUS_COMPONENT(SplitDestinationMapper)
 
         theTotalNumCores = Flexus::Core::ComponentManager::getComponentManager().systemWidth();
 
+        // The block interleaving is fixed to be 64. 
+        // If you modify this value, you need also to modify the checkpoint save/load logic of the CMPCache/StdArray.hpp
+        DBG_Assert(cfg.DirInterleaving == 64); 
+
         if (cfg.Cores == 0) cfg.Cores = theTotalNumCores;
 
         if (cfg.Directories == 0) cfg.Directories = theTotalNumCores;
@@ -724,6 +728,7 @@ class FLEXUS_COMPONENT(SplitDestinationMapper)
     inline int32_t getDirectoryLocation(const PhysicalMemoryAddress& anAddress)
     {
         if (theDirXORShift > 0) {
+            DBG_Assert(false);
             return ((anAddress >> theDirShift) ^ (anAddress >> theDirXORShift)) & theDirMask;
         } else {
             return ((anAddress >> theDirShift) & theDirMask) % cfg.Banks;


### PR DESCRIPTION
This PR contains the following changes:
1. It expands the number of sharers to 256 to support 128-core simulation.
2. It changes the format of the checkpoint. Instead of storing the whole LLC and the directory as one file, it stores each LLC slice and each directory slice as a file. This makes the checkpoint format incompatible with the KeenKraken. 
3. The interleaving granularity is strictly set to 64B. A larger granularity can be supported later, and requires the work from both Flexus side and the trace driven simulator side. All cache line accesses now have to check whether the address match the slice id. 
4. It replaces all uint32_t (when using as a size or an index) to uint64_t. 